### PR TITLE
FIx open api documentation in micro-services

### DIFF
--- a/engagement-service/src/main/java/com/mrs/engagement_service/module/rating/application/controller/RatingController.java
+++ b/engagement-service/src/main/java/com/mrs/engagement_service/module/rating/application/controller/RatingController.java
@@ -133,7 +133,7 @@ public class RatingController {
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/{ratingId}")
+    @DeleteMapping("/{ratingId}")
     @Operation(summary = "Delete rating", description = "Deletes an existing book rating")
     @SecurityRequirement(name = "bearerAuth")
     @ApiResponses(value = {


### PR DESCRIPTION
This pull request updates the `RatingController` to correct the HTTP method annotation for the endpoint that deletes a book rating. The endpoint now uses the appropriate `@DeleteMapping` annotation instead of `@PutMapping`.