### PR TITLE
#206 feat: enable Prometheus observability and harden actuator profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ GOOGLE_CLIENT_ID=your_google_client_id
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 ```
 
+For the Docker Compose `prod` profile used by the local stack, `JWT_KEY` is required by all five application services. `JWT_EXPIRATION_MS` is also required by `user-service`, and `GOOGLE_CLIENT_ID` is required for Google login support.
+
 Generate a local Base64 JWT key:
 
 ```bash
@@ -344,6 +346,10 @@ Services expose Spring Boot Actuator endpoints:
 - `/actuator/info`
 - `/actuator/metrics`
 - `/actuator/prometheus`
+
+`/actuator/prometheus` is backed by the Micrometer Prometheus registry and exports metrics with a common `service` tag. Health remains publicly reachable for Docker healthchecks. Prometheus is also reachable for local operational scraping, while broader Actuator endpoints such as `info` and `metrics` still require authentication on the application services and gateway.
+
+In the `prod` profile, health details are hidden and the gateway lowers Spring Cloud Gateway logging from local `TRACE` diagnostics to `INFO`.
 
 Kafka UI is available at `http://localhost:8090` when the compose stack is running. Additional Kafka monitoring notes live in [docs/KAFKA_MONITORING.md](docs/KAFKA_MONITORING.md), though the code-level topic inventory above is newer than parts of that document.
 

--- a/catalog-service/pom.xml
+++ b/catalog-service/pom.xml
@@ -42,6 +42,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/catalog-service/src/main/java/com/vellumhub/catalog_service/share/security/SecurityConfig.java
+++ b/catalog-service/src/main/java/com/vellumhub/catalog_service/share/security/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/actuator/health/**").permitAll()
+                        .requestMatchers("/actuator/health/**", "/actuator/prometheus").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/files/books/**").permitAll()
                         .anyRequest().authenticated()

--- a/catalog-service/src/main/resources/application-prod.properties
+++ b/catalog-service/src/main/resources/application-prod.properties
@@ -13,3 +13,5 @@ spring.flyway.baseline-on-migrate=true
 spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS}
 
 jwt.secret=${JWT_KEY}
+
+management.endpoint.health.show-details=never

--- a/catalog-service/src/main/resources/application.properties
+++ b/catalog-service/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.domain.name=catalog-service
+spring.application.name=catalog-service
 
 server.port=${SERVER_PORT:8080}
 
@@ -16,7 +16,8 @@ management.endpoint.health.probes.enabled=true
 management.health.livenessState.enabled=true
 management.health.readinessState.enabled=true
 management.health.kafka.enabled=true
-management.metrics.export.prometheus.enabled=true
+management.prometheus.metrics.export.enabled=true
+management.metrics.tags.service=${spring.application.name}
 
 spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS}
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/engagement-service/pom.xml
+++ b/engagement-service/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>

--- a/engagement-service/src/main/java/com/vellumhub/engagement_service/share/security/config/SecurityConfig.java
+++ b/engagement-service/src/main/java/com/vellumhub/engagement_service/share/security/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/actuator/health/**").permitAll()
+                        .requestMatchers("/actuator/health/**", "/actuator/prometheus").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/engagement-service/src/main/resources/application-prod.properties
+++ b/engagement-service/src/main/resources/application-prod.properties
@@ -18,6 +18,9 @@ spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS}
 # Security
 jwt.secret=${JWT_KEY}
 
+# Actuator
+management.endpoint.health.show-details=never
+
 # Logging
 logging.level.root=WARN
 logging.level.com.mrs.engagement_service=INFO

--- a/engagement-service/src/main/resources/application.properties
+++ b/engagement-service/src/main/resources/application.properties
@@ -42,7 +42,8 @@ management.endpoint.health.probes.enabled=true
 management.health.livenessState.enabled=true
 management.health.readinessState.enabled=true
 management.health.kafka.enabled=true
-management.metrics.export.prometheus.enabled=true
+management.prometheus.metrics.export.enabled=true
+management.metrics.tags.service=${spring.application.name}
 management.info.env.enabled=true
 
 # Loggings

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -76,6 +76,11 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>

--- a/gateway-service/src/main/java/com/vellumhub/gateway_service/config/security/GatewaySecurityConfig.java
+++ b/gateway-service/src/main/java/com/vellumhub/gateway_service/config/security/GatewaySecurityConfig.java
@@ -25,7 +25,7 @@ public class GatewaySecurityConfig {
         return http
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 .authorizeExchange(exchanges -> exchanges
-                        .pathMatchers("/actuator/**").permitAll()
+                        .pathMatchers("/actuator/health/**", "/actuator/prometheus").permitAll()
                         .pathMatchers("/api/v1/auth/**").permitAll()
                         .anyExchange().authenticated()
                 )

--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -1,0 +1,15 @@
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          secret-key: ${JWT_KEY}
+
+management:
+  endpoint:
+    health:
+      show-details: never
+
+logging:
+  level:
+    org.springframework.cloud.gateway: INFO

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -80,7 +80,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          secret-key: ${JWT_KEY:dasdasidaidIHDASOHDOASHDPHAsdhashdouahsoduahsoduaoudhaoudhohdouashd}
+          secret-key: ${JWT_KEY_LOCAL:dasdasidaidIHDASOHDOASHDPHAsdhashdouahsoduahsoduaoudhaoudhohdouashd}
 
   data:
     redis:
@@ -107,7 +107,10 @@ management:
       enabled: true
     kafka:
       enabled: true
-  metrics:
-    export:
-      prometheus:
+  prometheus:
+    metrics:
+      export:
         enabled: true
+  metrics:
+    tags:
+      service: ${spring.application.name}

--- a/recommendation-service/pom.xml
+++ b/recommendation-service/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>

--- a/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/security/config/SecurityConfig.java
+++ b/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/security/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/actuator/health/**").permitAll()
+                        .requestMatchers("/actuator/health/**", "/actuator/prometheus").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/recommendation-service/src/main/resources/application-prod.properties
+++ b/recommendation-service/src/main/resources/application-prod.properties
@@ -14,3 +14,5 @@ spring.flyway.baseline-on-migrate=true
 catalog-service.url=http://catalog-service:8080
 
 jwt.secret=${JWT_KEY}
+
+management.endpoint.health.show-details=never

--- a/recommendation-service/src/main/resources/application-test.properties
+++ b/recommendation-service/src/main/resources/application-test.properties
@@ -26,3 +26,5 @@ spring.kafka.consumer.group-id=recommendation-group-test
 # Disable Kafka health check for tests
 management.health.kafka.enabled=false
 
+# JWT Secret for tests
+jwt.secret=dGVzdC1zZWNyZXQta2V5LWZvci10ZXN0aW5nLXB1cnBvc2VzLXdpdGgtYXQtbGVhc3QtMjU2LWJpdHM=

--- a/recommendation-service/src/main/resources/application.properties
+++ b/recommendation-service/src/main/resources/application.properties
@@ -17,7 +17,8 @@ management.endpoint.health.probes.enabled=true
 management.health.livenessState.enabled=true
 management.health.readinessState.enabled=true
 management.health.kafka.enabled=true
-management.metrics.export.prometheus.enabled=true
+management.prometheus.metrics.export.enabled=true
+management.metrics.tags.service=${spring.application.name}
 
 spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS}
 

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -31,6 +31,10 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>

--- a/user-service/src/main/java/com/vellumhub/user_service/share/security/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/vellumhub/user_service/share/security/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/actuator/health").permitAll()
+                        .requestMatchers("/actuator/health/**", "/actuator/prometheus").permitAll()
                         .requestMatchers("/auth/login", "/auth/register").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()

--- a/user-service/src/main/resources/application-prod.properties
+++ b/user-service/src/main/resources/application-prod.properties
@@ -14,3 +14,5 @@ spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS}
 
 jwt.secret=${JWT_KEY}
 jwt.expiration-ms=${JWT_EXPIRATION_MS}
+
+management.endpoint.health.show-details=never

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -13,7 +13,8 @@ management.endpoint.health.probes.enabled=true
 management.health.livenessState.enabled=true
 management.health.readinessState.enabled=true
 management.health.kafka.enabled=true
-management.metrics.export.prometheus.enabled=true
+management.prometheus.metrics.export.enabled=true
+management.metrics.tags.service=${spring.application.name}
 
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer


### PR DESCRIPTION
This pull request introduces consistent Prometheus metrics support and improved Actuator endpoint configuration across all application services. It adds the Prometheus registry dependency, ensures `/actuator/prometheus` is publicly accessible, standardizes metrics tags, and enhances documentation. Additionally, it updates health endpoint visibility and logging settings for production.

**Prometheus Metrics Integration and Actuator Endpoint Exposure:**

* Added the `micrometer-registry-prometheus` dependency to all service `pom.xml` files to enable Prometheus metrics export. [[1]](diffhunk://#diff-630de164260825f6272fb7c40b3f93abf4ad60b8139ad26d2da132545a61d0c2R45-R48) [[2]](diffhunk://#diff-e42ea32b0293aeb4cc1a0b85cf31ce198c4b3ef0ebbf9aa388b4791824560390R31-R34) [[3]](diffhunk://#diff-8a19809aa7b8dea097f26b36d0ca7f8c8af244ace1c108b74818defd1282db7aR79-R83) [[4]](diffhunk://#diff-89c6a3a076608594c1e111840bc0855ff09d094aad3c4b1f65348eeb982a56d4R33-R36) [[5]](diffhunk://#diff-8ec08ada4610a6e96e9613a2417ad376b00f9bd8a0926ec70623397d9b8c51b6R33-R36)
* Updated security configurations to permit unauthenticated access to `/actuator/prometheus` in all services, alongside `/actuator/health/**`. [[1]](diffhunk://#diff-00ebd1572518850ab1bf62c3dd7a279e54db4bf9a831cd9a3c34c91870d3cb5bL59-R59) [[2]](diffhunk://#diff-d1b25f83573f2a554cdfe3a44fee98a0ba6a6393418278df963fa3af7d69dd9dL59-R59) [[3]](diffhunk://#diff-c1f5933006c67ffe64d2a5dbeed1902eff50dbe0fe78e6e4d2e5d43e071ad5c8L28-R28) [[4]](diffhunk://#diff-2df5fa2f1c6b9ea8d25835ea9d7c44a2692bc4711c74d957079f578a6c50b3fbL59-R59) [[5]](diffhunk://#diff-574fbe737511b272c47bf48026a974ad0c9fed58fce7301b76bbdee60811bb33L47-R47)
* Standardized Prometheus metrics export configuration and added a common `service` tag using `${spring.application.name}` in all `application.properties` files. [[1]](diffhunk://#diff-e427464556d9420a8b52ff03bf5baaf726a20697253cefbdf3830c2084801b2eL19-R20) [[2]](diffhunk://#diff-083fcd0840219d9a1209f3a7388bd69f69edabdfa93124c8140c01ba4f620a6cL45-R46) [[3]](diffhunk://#diff-81591baee65394b4787ea8685505f9db3b963169d1f89e93be98c4c53e755aefR110-R116) [[4]](diffhunk://#diff-3a9379bde2b2562079a21805f646140631e0a76e41fb5c32dffde6eb93877c24L20-R21)

**Production Profile and Logging Improvements:**

* Set `management.endpoint.health.show-details=never` in all `application-prod.properties`/`application-prod.yml` files to hide health details in production. Adjusted gateway logging to `INFO` in production. [[1]](diffhunk://#diff-78fbce22f42ec780fadff6c09e1ddd7bbe94d8f33aba4c4634dce152867fd255R16-R17) [[2]](diffhunk://#diff-340ba0e45b76b9e105fb979fcc4be87127a2a2f4feebfc07b5ee1b60b7f03f70R21-R23) [[3]](diffhunk://#diff-eb050f609c3c73a6a3c3e564c859129aaf40653c1fbd3f85d0b119fd6a54d18dR1-R15) [[4]](diffhunk://#diff-69a6fb06b3f2ee272a9a84bae06a31244b6a4ec0faa0423752f0a68167073c4fR17-R18)
* Updated gateway JWT secret property for local and production environments.

**Documentation Updates:**

* Expanded the `README.md` to clarify Prometheus metrics support, Actuator endpoint accessibility, and required environment variables for local and production Docker Compose profiles. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R235-R236) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R350-R353)

**Miscellaneous Configuration Fixes:**

* Renamed `spring.domain.name` to `spring.application.name` in `catalog-service` for consistency.
* Added a test JWT secret to `recommendation-service` test properties.