### PR TITLE
#204 feat: implement distributed tracing using OpenTelemetry and Tempo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ VellumHub demonstrates:
 - **Recommendation architecture:** the recommendation service stores local `book_features`, `user_profiles`, and `recommendations` data, with pgvector similarity search over `vector(384)` embeddings.
 - **Gateway control plane:** Spring Cloud Gateway WebFlux enforces route-level JWT authentication and Redis-backed rate limiting before traffic reaches internal services.
 - **Kafka resilience:** recommendation and engagement consumers use Spring Kafka retry topics and Dead Letter Topic handling for unrecoverable events.
-- **Operational visibility:** services expose Actuator health, metrics, and Prometheus endpoints; Kafka UI is included for local topic and consumer inspection; the optional observability profile adds Prometheus, Grafana, Loki, Tempo, and Alloy.
+- **Operational visibility:** services expose Actuator health, metrics, Prometheus endpoints, structured logs, and OpenTelemetry Java Agent traces; Kafka UI is included for local topic and consumer inspection; the optional observability profile adds Prometheus, Grafana, Loki, Tempo, and Alloy.
 
 The current architecture is best described as a mature v3 platform moving through v4 reliability hardening: contracts, schema evolution, outbox, idempotency, tracing, and integration testing are now the focus.
 
@@ -355,7 +355,7 @@ Services expose Spring Boot Actuator endpoints:
 - `/actuator/metrics`
 - `/actuator/prometheus`
 
-`/actuator/prometheus` is backed by the Micrometer Prometheus registry and exports metrics with a common `service` tag. Health remains publicly reachable for Docker healthchecks. The observability profile scrapes these endpoints through Prometheus and provisions Grafana with Prometheus, Loki, and Tempo datasources. Broader Actuator endpoints such as `info` and `metrics` still require authentication on the application services and gateway.
+`/actuator/prometheus` is backed by the Micrometer Prometheus registry and exports metrics with a common `service` tag. Health remains publicly reachable for Docker healthchecks. The observability profile scrapes these endpoints through Prometheus, ships structured Docker logs to Loki, forwards OpenTelemetry Java Agent traces through Alloy to Tempo, and provisions Grafana with Prometheus, Loki, and Tempo datasources. Broader Actuator endpoints such as `info` and `metrics` still require authentication on the application services and gateway.
 
 In the `prod` profile, health details are hidden and the gateway lowers Spring Cloud Gateway logging from local `TRACE` diagnostics to `INFO`.
 
@@ -403,7 +403,7 @@ Latest recorded passing local verification in this workspace was performed on 20
 - Unit and slice tests cover domain models, use cases, controllers, Kafka consumers, mappers, and repository adapters in the strongest-covered services.
 - Kafka retry/DLT behavior is implemented in engagement and recommendation, but end-to-end retry/DLT verification still needs Testcontainers coverage.
 - Docker Compose defines service healthchecks for gateway, databases, Redis, Kafka, and application services.
-- Actuator, metrics, Prometheus endpoints, Kafka UI, and the optional Grafana/Prometheus/Loki/Tempo/Alloy profile provide local operational inspection.
+- Actuator, metrics, Prometheus endpoints, structured logs, OpenTelemetry Java Agent traces, Kafka UI, and the optional Grafana/Prometheus/Loki/Tempo/Alloy profile provide local operational inspection.
 - Coverage percentage is not claimed because no local JaCoCo configuration or generated coverage report was found during inspection.
 - Docker Compose configuration rendered successfully during local inspection, but a full `docker-compose up` health verification was not part of this README pass.
 
@@ -416,7 +416,7 @@ VellumHub is a mature v3 platform moving through v4 reliability hardening. The f
 | Kafka contracts | Centralize topic names, align producers/consumers/retry configs, and add contract tests ([#199](https://github.com/Luca5Eckert/VellumHub/issues/199)). |
 | Consumer idempotency | Add `processed_events` handling for at-least-once Kafka delivery ([#200](https://github.com/Luca5Eckert/VellumHub/issues/200)). |
 | Transactional outbox | Persist catalog and engagement changes with outgoing events atomically ([#201](https://github.com/Luca5Eckert/VellumHub/issues/201), [#202](https://github.com/Luca5Eckert/VellumHub/issues/202)). |
-| Distributed tracing | Propagate correlation IDs through gateway, HTTP calls, Kafka headers, and logs ([#204](https://github.com/Luca5Eckert/VellumHub/issues/204)). |
+| Distributed tracing | Local OpenTelemetry Java Agent tracing is wired to Alloy and Tempo; follow-up work can add manual domain spans or Kafka propagation only where automatic instrumentation is insufficient ([#204](https://github.com/Luca5Eckert/VellumHub/issues/204)). |
 | Database migrations | Replace production `ddl-auto=update` behavior with Flyway migrations and validation ([#205](https://github.com/Luca5Eckert/VellumHub/issues/205)). |
 | Operational security | Harden Actuator exposure, secret defaults, and production logging ([#206](https://github.com/Luca5Eckert/VellumHub/issues/206)). |
 | Integration tests | Add Testcontainers coverage for PostgreSQL, Kafka, retry/DLT, and projection flows ([#207](https://github.com/Luca5Eckert/VellumHub/issues/207)). |

--- a/catalog-service/Dockerfile
+++ b/catalog-service/Dockerfile
@@ -15,6 +15,14 @@ COPY src ./src
 # ✅ Compilar o projeto (mais rápido porque deps já estão baixadas)
 RUN mvn clean package -DskipTests -B
 
+ARG OTEL_JAVA_AGENT_VERSION=2.28.1
+RUN mvn dependency:copy \
+  -Dartifact=io.opentelemetry.javaagent:opentelemetry-javaagent:${OTEL_JAVA_AGENT_VERSION}:jar \
+  -DoutputDirectory=/otel \
+  -Dmdep.stripVersion=true \
+  -Dtransitive=false \
+  -B
+
 # STAGE 2: Runtime
 FROM eclipse-temurin:21-jre-alpine
 
@@ -22,6 +30,7 @@ WORKDIR /app
 
 # ✅ Copiar apenas o JAR compilado
 COPY --from=build /app/target/*.jar app.jar
+COPY --from=build /otel/opentelemetry-javaagent.jar opentelemetry-javaagent.jar
 
 # ✅ Adicionar healthcheck
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s \

--- a/catalog-service/pom.xml
+++ b/catalog-service/pom.xml
@@ -125,7 +125,7 @@
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-jackson</artifactId>
-			<version>0.11.5</version>
+			<version>0.12.6</version>
 			<scope>runtime</scope>
 		</dependency>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,15 @@ networks:
   vellum-network:
     driver: bridge
 
+x-otel-java-env: &otel-java-env
+  OTEL_RESOURCE_ATTRIBUTES: service.namespace=vellumhub,deployment.environment=local
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://alloy:4318
+  OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+  OTEL_METRICS_EXPORTER: none
+  OTEL_LOGS_EXPORTER: none
+  OTEL_TRACES_SAMPLER: parentbased_traceidratio
+  OTEL_TRACES_SAMPLER_ARG: "1.0"
+
 services:
 
   # GATEWAY LAYER
@@ -16,9 +25,11 @@ services:
       - "8080:8080"
     env_file: .env
     environment:
+      <<: *otel-java-env
       SPRING_PROFILES_ACTIVE: prod
       SERVER_PORT: 8080
-      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m"
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m -javaagent:/app/opentelemetry-javaagent.jar"
+      OTEL_SERVICE_NAME: gateway-service
       SPRING_DATA_REDIS_HOST: redis-gateway
       SPRING_DATA_REDIS_PORT: 6379
       USER_SERVICE_URL: http://user-service:8080
@@ -321,9 +332,11 @@ services:
     restart: on-failure
     env_file: .env
     environment:
+      <<: *otel-java-env
       SPRING_PROFILES_ACTIVE: prod
       SERVER_PORT: 8080
-      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m"
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m -javaagent:/app/opentelemetry-javaagent.jar"
+      OTEL_SERVICE_NAME: catalog-service
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres-catalog:5432/catalog_db
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
@@ -351,9 +364,11 @@ services:
     restart: on-failure
     env_file: .env
     environment:
+      <<: *otel-java-env
       SPRING_PROFILES_ACTIVE: prod
       SERVER_PORT: 8080
-      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m"
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m -javaagent:/app/opentelemetry-javaagent.jar"
+      OTEL_SERVICE_NAME: engagement-service
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres-engagement:5432/engagement_db
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
@@ -381,9 +396,11 @@ services:
     restart: on-failure
     env_file: .env
     environment:
+      <<: *otel-java-env
       SPRING_PROFILES_ACTIVE: prod
       SERVER_PORT: 8080
-      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m"
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m -javaagent:/app/opentelemetry-javaagent.jar"
+      OTEL_SERVICE_NAME: user-service
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres-user:5432/user_db
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
@@ -413,10 +430,12 @@ services:
     restart: on-failure
     env_file: .env
     environment:
+      <<: *otel-java-env
       SPRING_PROFILES_ACTIVE: prod
       SERVER_PORT: 8080
       SPRING_MAIN_ALLOW_BEAN_DEFINITION_OVERRIDING: "true"
-      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m"
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m -javaagent:/app/opentelemetry-javaagent.jar"
+      OTEL_SERVICE_NAME: recommendation-service
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres-recommendation:5432/recommendation_db
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,6 +1,6 @@
 # Observability Stack
 
-VellumHub ships a local observability profile for development. It collects application metrics, container logs, and future OTLP traces without depending on external infrastructure.
+VellumHub ships a local observability profile for development. It collects application metrics, container logs, and OTLP traces without depending on external infrastructure.
 
 ## Start The Stack
 
@@ -8,6 +8,7 @@ Render the Compose model before starting it:
 
 ```bash
 docker compose --profile observability config
+
 ```
 
 Start the default application stack plus observability services:
@@ -83,12 +84,49 @@ Dead Letter Topic logs include topic names, exception message, and payload byte 
 
 ## Traces
 
-Tempo is provisioned in Grafana and Alloy includes OTLP receivers that forward traces to Tempo. The Java services are not deeply instrumented in this issue, so `trace_id` and `span_id` appear in logs only when future tracing instrumentation populates MDC or structured log key-value data.
+The five Java service images include the OpenTelemetry Java Agent `v2.28.1`. Docker Compose enables the agent through `JAVA_TOOL_OPTIONS` while preserving the existing heap flags.
 
-Services running inside Docker can send OTLP to:
+Each service sets:
+
+- `OTEL_SERVICE_NAME` to the Docker service name.
+- `OTEL_RESOURCE_ATTRIBUTES=service.namespace=vellumhub,deployment.environment=local`.
+- `OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318`.
+- `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
+- `OTEL_METRICS_EXPORTER=none`.
+- `OTEL_LOGS_EXPORTER=none`.
+- `OTEL_TRACES_SAMPLER=parentbased_traceidratio`.
+- `OTEL_TRACES_SAMPLER_ARG=1.0`.
+
+Metrics and logs export through the OpenTelemetry agent is intentionally disabled. Prometheus/Micrometer remains the metrics path, and structured Docker logs continue to flow through Alloy to Loki.
+
+Services running inside Docker send OTLP to Alloy:
 
 - `http://alloy:4318` for OTLP HTTP
 - `alloy:4317` for OTLP gRPC
+
+Alloy forwards traces to Tempo over OTLP gRPC. Grafana provisions Tempo as the `Tempo` datasource.
+
+To generate a minimal gateway span:
+
+```bash
+curl http://localhost:8080/actuator/health
+```
+
+To generate a gateway-to-service trace, call one of the public gateway routes, for example:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"name":"OTel Local","email":"otel-local@example.com","password":"StrongPass123!"}'
+```
+
+Then open Grafana Explore at `http://localhost:3002`, select `Tempo`, and search by service name such as `gateway-service` or `catalog-service`. Tempo can also be queried directly:
+
+```bash
+curl "http://localhost:3200/api/search?tags=service.name%3Dgateway-service&limit=20"
+```
+
+HTTP server/client spans and JDBC spans are expected when the Java agent supports the Spring, Reactor Netty, servlet, JDBC, Hikari, and PostgreSQL versions in the running service. Kafka producer-to-consumer correlation is best-effort with automatic instrumentation; if a Kafka flow appears as separate traces, keep that as a follow-up for manual propagation or targeted Kafka instrumentation.
 
 ## Sensitive Data Checks
 
@@ -115,4 +153,4 @@ The expected behavior is:
 | `docker/observability/tempo/tempo.yml` | Local Tempo trace storage and OTLP receiver config. |
 | `docker/observability/alloy/config.alloy` | Docker log collection, Loki forwarding, and OTLP-to-Tempo forwarding. |
 
-Dashboards, alerts, business metrics, and deep tracing instrumentation are intentionally outside this issue.
+Dashboards, alerts, business metrics, and manual domain spans are intentionally outside this issue.

--- a/engagement-service/Dockerfile
+++ b/engagement-service/Dockerfile
@@ -15,6 +15,14 @@ COPY src ./src
 # ✅ Compilar o projeto (mais rápido porque deps já estão baixadas)
 RUN mvn clean package -DskipTests -B
 
+ARG OTEL_JAVA_AGENT_VERSION=2.28.1
+RUN mvn dependency:copy \
+  -Dartifact=io.opentelemetry.javaagent:opentelemetry-javaagent:${OTEL_JAVA_AGENT_VERSION}:jar \
+  -DoutputDirectory=/otel \
+  -Dmdep.stripVersion=true \
+  -Dtransitive=false \
+  -B
+
 # STAGE 2: Runtime
 FROM eclipse-temurin:21-jre-alpine
 
@@ -22,6 +30,7 @@ WORKDIR /app
 
 # ✅ Copiar apenas o JAR compilado
 COPY --from=build /app/target/*.jar app.jar
+COPY --from=build /otel/opentelemetry-javaagent.jar opentelemetry-javaagent.jar
 
 # ✅ Adicionar healthcheck
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s \

--- a/engagement-service/pom.xml
+++ b/engagement-service/pom.xml
@@ -106,7 +106,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- JWT -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
@@ -121,7 +120,7 @@
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId>
-            <version>0.11.5</version>
+            <version>0.12.6</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/gateway-service/Dockerfile
+++ b/gateway-service/Dockerfile
@@ -15,6 +15,14 @@ COPY src ./src
 # ✅ Compilar o projeto (mais rápido porque deps já estão baixadas)
 RUN mvn clean package -DskipTests -B
 
+ARG OTEL_JAVA_AGENT_VERSION=2.28.1
+RUN mvn dependency:copy \
+  -Dartifact=io.opentelemetry.javaagent:opentelemetry-javaagent:${OTEL_JAVA_AGENT_VERSION}:jar \
+  -DoutputDirectory=/otel \
+  -Dmdep.stripVersion=true \
+  -Dtransitive=false \
+  -B
+
 # STAGE 2: Runtime
 FROM eclipse-temurin:21-jre-alpine
 
@@ -22,6 +30,7 @@ WORKDIR /app
 
 # ✅ Copiar apenas o JAR compilado
 COPY --from=build /app/target/*.jar app.jar
+COPY --from=build /otel/opentelemetry-javaagent.jar opentelemetry-javaagent.jar
 
 # ✅ Adicionar healthcheck
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s \

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-jackson</artifactId>
-			<version>0.11.5</version>
+			<version>0.12.6</version>
 			<scope>runtime</scope>
 		</dependency>
 

--- a/recommendation-service/Dockerfile
+++ b/recommendation-service/Dockerfile
@@ -6,6 +6,14 @@ RUN mvn dependency:go-offline -B
 COPY src ./src
 RUN mvn clean package -DskipTests -B
 
+ARG OTEL_JAVA_AGENT_VERSION=2.28.1
+RUN mvn dependency:copy \
+  -Dartifact=io.opentelemetry.javaagent:opentelemetry-javaagent:${OTEL_JAVA_AGENT_VERSION}:jar \
+  -DoutputDirectory=/otel \
+  -Dmdep.stripVersion=true \
+  -Dtransitive=false \
+  -B
+
 FROM eclipse-temurin:21-jre
 
 # Debian-based images don't need gcompat, but we ensure basic tools are there
@@ -16,6 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY --from=build /app/target/*.jar app.jar
+COPY --from=build /otel/opentelemetry-javaagent.jar opentelemetry-javaagent.jar
 
 # Standard Spring Boot healthcheck
 HEALTHCHECK --interval=30s --timeout=3s --start-period=60s \

--- a/recommendation-service/pom.xml
+++ b/recommendation-service/pom.xml
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId>
-            <version>0.11.5</version>
+            <version>0.12.6</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -15,6 +15,14 @@ COPY src ./src
 # ✅ Compilar o projeto (mais rápido porque deps já estão baixadas)
 RUN mvn clean package -DskipTests -B
 
+ARG OTEL_JAVA_AGENT_VERSION=2.28.1
+RUN mvn dependency:copy \
+  -Dartifact=io.opentelemetry.javaagent:opentelemetry-javaagent:${OTEL_JAVA_AGENT_VERSION}:jar \
+  -DoutputDirectory=/otel \
+  -Dmdep.stripVersion=true \
+  -Dtransitive=false \
+  -B
+
 # STAGE 2: Runtime
 FROM eclipse-temurin:21-jre-alpine
 
@@ -22,6 +30,7 @@ WORKDIR /app
 
 # ✅ Copiar apenas o JAR compilado
 COPY --from=build /app/target/*.jar app.jar
+COPY --from=build /otel/opentelemetry-javaagent.jar opentelemetry-javaagent.jar
 
 # ✅ Adicionar healthcheck
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s \

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -85,7 +85,7 @@
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-jackson</artifactId>
-			<version>0.11.5</version>
+			<version>0.12.6</version>
 			<scope>runtime</scope>
 		</dependency>
 


### PR DESCRIPTION
This pull request introduces distributed tracing to all Java services in the VellumHub platform using the OpenTelemetry Java Agent, and updates documentation to reflect the new observability stack. It also upgrades the JWT library version across services. The main changes are grouped below:

**Distributed Tracing and Observability Enhancements:**

* Adds the OpenTelemetry Java Agent (`v2.28.1`) to all Java service Docker images (`gateway-service`, `catalog-service`, `engagement-service`, `recommendation-service`, `user-service`) and configures it in Docker Compose to export traces to Alloy and Tempo, with service-specific OTEL variables and agent flags. Metrics and log export via the agent are disabled in favor of existing Prometheus and Loki pipelines. [[1]](diffhunk://#diff-58c5e548c49bad79f91d2e2b17a91ad1fd0bd8a55cf383c8e584f48bfb337667R18-R33)], [[2]](diffhunk://#diff-4756e0c6a0496ec597634087973c516be0e75d9286176a1a5809afa83643886cR18-R33)], [[3]](diffhunk://#diff-c0dfb9acc7dde2fe2c18718b688a2615301fbedc1af92375f06b6327a0984a5aR9-R16)], [[4]](diffhunk://#diff-c0dfb9acc7dde2fe2c18718b688a2615301fbedc1af92375f06b6327a0984a5aR27)], [F356304aL6R6], [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R28-R32)], [[6]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R335-R339)], [[7]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R367-R371)], [[8]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R399-R403)], [[9]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R433-R438)])
* Updates documentation (`README.md`, `docs/OBSERVABILITY.md`) to describe the new tracing setup, including how traces are generated, discovered in Grafana Tempo, and the agent's configuration. It clarifies that manual domain spans and deep instrumentation are deferred. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R54)], [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L358-R358)], [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L406-R406)], [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L419-R419)], [[5]](diffhunk://#diff-3806ad73c39cafe7bbc7c33ba476d076c9eca7dd920b004c13dc14c003f4a004L3-R11)], [[6]](diffhunk://#diff-3806ad73c39cafe7bbc7c33ba476d076c9eca7dd920b004c13dc14c003f4a004L86-R130)], [[7]](diffhunk://#diff-3806ad73c39cafe7bbc7c33ba476d076c9eca7dd920b004c13dc14c003f4a004L118-R156)])

**Dependency Updates:**

* Upgrades the `io.jsonwebtoken:jjwt-jackson` dependency from `0.11.5` to `0.12.6` in all Java services to address security or compatibility improvements. [[1]](diffhunk://#diff-630de164260825f6272fb7c40b3f93abf4ad60b8139ad26d2da132545a61d0c2L128-R128)], [[2]](diffhunk://#diff-e42ea32b0293aeb4cc1a0b85cf31ce198c4b3ef0ebbf9aa388b4791824560390L124-R123)], [[3]](diffhunk://#diff-8a19809aa7b8dea097f26b36d0ca7f8c8af244ace1c108b74818defd1282db7aL70-R70)], [[4]](diffhunk://#diff-89c6a3a076608594c1e111840bc0855ff09d094aad3c4b1f65348eeb982a56d4L147-R147)], [[5]](diffhunk://#diff-8ec08ada4610a6e96e9613a2417ad376b00f9bd8a0926ec70623397d9b8c51b6L88-R88)])

These changes collectively enable out-of-the-box distributed tracing for local development and improve the observability posture of the platform.