### PR TITLE
#209 feat: provision observability dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Services expose Spring Boot Actuator endpoints:
 
 In the `prod` profile, health details are hidden and the gateway lowers Spring Cloud Gateway logging from local `TRACE` diagnostics to `INFO`.
 
-Kafka UI is available at `http://localhost:8090` when the compose stack is running. The full local observability workflow is documented in [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md), and additional Kafka monitoring notes live in [docs/KAFKA_MONITORING.md](docs/KAFKA_MONITORING.md), though the code-level topic inventory above is newer than parts of that document.
+Kafka UI is available at `http://localhost:8090` when the compose stack is running. The full local observability workflow is documented in [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md), operational incident guides live in [docs/OBSERVABILITY_RUNBOOKS.md](docs/OBSERVABILITY_RUNBOOKS.md), and additional Kafka monitoring notes live in [docs/KAFKA_MONITORING.md](docs/KAFKA_MONITORING.md), though the code-level topic inventory above is newer than parts of that document.
 
 ## Quality Evidence
 

--- a/catalog-service/src/main/java/com/vellumhub/catalog_service/share/config/InitialGenreSeeder.java
+++ b/catalog-service/src/main/java/com/vellumhub/catalog_service/share/config/InitialGenreSeeder.java
@@ -1,0 +1,50 @@
+package com.vellumhub.catalog_service.share.config;
+
+import com.vellumhub.catalog_service.module.book.domain.model.Genre;
+import com.vellumhub.catalog_service.module.book.infrastructure.repository.genre.JpaGenreRepository;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+class InitialGenreSeeder implements ApplicationRunner {
+
+    static final List<String> INITIAL_GENRES = List.of(
+            "Science Fiction",
+            "Fantasy",
+            "Horror",
+            "Romance",
+            "Thriller",
+            "Biography",
+            "History",
+            "Self-Help",
+            "Dystopian",
+            "Adventure"
+    );
+
+    private final JpaGenreRepository genreRepository;
+    private final List<String> initialGenres;
+
+    InitialGenreSeeder(JpaGenreRepository genreRepository) {
+        this(genreRepository, INITIAL_GENRES);
+    }
+
+    InitialGenreSeeder(JpaGenreRepository genreRepository, List<String> initialGenres) {
+        this.genreRepository = genreRepository;
+        this.initialGenres = initialGenres;
+    }
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        initialGenres.stream()
+                .map(String::trim)
+                .filter(name -> !name.isBlank())
+                .filter(name -> !genreRepository.existsByName(name))
+                .map(Genre::new)
+                .forEach(genreRepository::save);
+    }
+}

--- a/catalog-service/src/test/java/com/vellumhub/catalog_service/share/config/InitialGenreSeederTest.java
+++ b/catalog-service/src/test/java/com/vellumhub/catalog_service/share/config/InitialGenreSeederTest.java
@@ -1,0 +1,56 @@
+package com.vellumhub.catalog_service.share.config;
+
+import com.vellumhub.catalog_service.module.book.domain.model.Genre;
+import com.vellumhub.catalog_service.module.book.infrastructure.repository.genre.JpaGenreRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class InitialGenreSeederTest {
+
+    private final JpaGenreRepository genreRepository = org.mockito.Mockito.mock(JpaGenreRepository.class);
+    private final InitialGenreSeeder seeder = new InitialGenreSeeder(genreRepository);
+
+    @Test
+    void shouldDefineTenInitialGenres() {
+        assertThat(InitialGenreSeeder.INITIAL_GENRES)
+                .containsExactly(
+                        "Science Fiction",
+                        "Fantasy",
+                        "Horror",
+                        "Romance",
+                        "Thriller",
+                        "Biography",
+                        "History",
+                        "Self-Help",
+                        "Dystopian",
+                        "Adventure"
+                );
+    }
+
+    @Test
+    void shouldCreateOnlyMissingGenres() throws Exception {
+        when(genreRepository.existsByName("Fantasy")).thenReturn(true);
+        when(genreRepository.existsByName("Adventure")).thenReturn(false);
+        InitialGenreSeeder seeder = new InitialGenreSeeder(genreRepository, java.util.List.of("Fantasy", "Adventure"));
+
+        seeder.run(null);
+
+        verify(genreRepository, never()).save(new Genre("Fantasy"));
+        verify(genreRepository).save(new Genre("Adventure"));
+    }
+
+    @Test
+    void shouldSkipBlankGenreNames() throws Exception {
+        InitialGenreSeeder seeder = new InitialGenreSeeder(genreRepository, java.util.List.of(" ", ""));
+
+        seeder.run(null);
+
+        verify(genreRepository, never()).existsByName(any());
+        verify(genreRepository, never()).save(any());
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,6 +232,7 @@ services:
       - "9090:9090"
     volumes:
       - ./docker/observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./docker/observability/prometheus/rules:/etc/prometheus/rules:ro
       - prometheus_data:/prometheus
     command:
       - --config.file=/etc/prometheus/prometheus.yml

--- a/docker/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/docker/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: VellumHub
+    orgId: 1
+    folder: VellumHub
+    folderUid: vellumhub
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards/json
+      foldersFromFilesStructure: false

--- a/docker/observability/grafana/provisioning/dashboards/json/vellumhub-gateway-http.json
+++ b/docker/observability/grafana/provisioning/dashboards/json/vellumhub-gateway-http.json
@@ -1,0 +1,86 @@
+{
+  "uid": "vellumhub-gateway-http",
+  "title": "Gateway and HTTP",
+  "tags": ["vellumhub", "gateway", "http"],
+  "timezone": "browser",
+  "schemaVersion": 41,
+  "version": 1,
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Gateway Requests by Public Route",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (uri, method) (rate(http_server_requests_seconds_count{job=\"gateway-service\"}[5m]))", "legendFormat": "{{method}} {{uri}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Gateway 4xx and 5xx",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (status) (rate(http_server_requests_seconds_count{job=\"gateway-service\",status=~\"4..|5..\"}[5m]))", "legendFormat": "{{status}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Gateway Latency by Route",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "histogram_quantile(0.95, sum by (le, uri) (rate(http_server_requests_seconds_bucket{job=\"gateway-service\"}[5m]))) or max by (uri) (http_server_requests_seconds_max{job=\"gateway-service\"})", "legendFormat": "p95 {{uri}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Rate Limit Signals",
+      "description": "Counts 429 responses when the Redis-backed gateway limiter rejects traffic.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (uri) (rate(http_server_requests_seconds_count{job=\"gateway-service\",status=\"429\"}[5m]))", "legendFormat": "{{uri}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Redis Command Latency / Activity",
+      "description": "Appears when Redis client command metrics are emitted by the gateway.",
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(redis_commands_duration_seconds_count{job=\"gateway-service\"}[5m])) or vector(0)", "legendFormat": "commands/s" },
+        { "refId": "B", "expr": "max(redis_commands_duration_seconds_max{job=\"gateway-service\"}) or vector(0)", "legendFormat": "max latency" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 6,
+      "type": "logs",
+      "title": "Gateway Error Logs",
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        { "refId": "A", "expr": "{service=\"gateway-service\", level=\"ERROR\"}" }
+      ],
+      "options": { "showLabels": true, "showTime": true, "wrapLogMessage": true }
+    }
+  ]
+}

--- a/docker/observability/grafana/provisioning/dashboards/json/vellumhub-kafka-flow.json
+++ b/docker/observability/grafana/provisioning/dashboards/json/vellumhub-kafka-flow.json
@@ -1,0 +1,88 @@
+{
+  "uid": "vellumhub-kafka-flow",
+  "title": "Kafka Flow",
+  "tags": ["vellumhub", "kafka", "events"],
+  "timezone": "browser",
+  "schemaVersion": 41,
+  "version": 1,
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Published Events",
+      "description": "Future business metric from #210.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (service, topic) (rate(vellumhub_kafka_producer_events_total[5m])) or vector(0)", "legendFormat": "{{service}} {{topic}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Consumed Events",
+      "description": "Future business metric from #210.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (service, topic) (rate(vellumhub_kafka_consumer_events_total[5m])) or vector(0)", "legendFormat": "{{service}} {{topic}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Publication and Consumption Failures",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (service, topic) (rate(vellumhub_kafka_producer_failures_total[5m])) or vector(0)", "legendFormat": "publish {{service}} {{topic}}" },
+        { "refId": "B", "expr": "sum by (service, topic) (rate(vellumhub_kafka_consumer_failures_total[5m])) or vector(0)", "legendFormat": "consume {{service}} {{topic}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Consumer Lag",
+      "description": "Uses Micrometer Kafka client lag metrics when available.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "max by (job) (kafka_consumer_fetch_manager_records_lag_max{job=~\".*-service\"}) or vector(0)", "legendFormat": "{{job}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 5,
+      "type": "logs",
+      "title": "DLT Logs",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        { "refId": "A", "expr": "{environment=\"local\"} |= \"DLT\"" }
+      ],
+      "options": { "showLabels": true, "showTime": true, "wrapLogMessage": true }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "DLT Metrics",
+      "description": "Future DLT counter from #210.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (service, topic) (rate(vellumhub_kafka_dlt_events_total[5m])) or vector(0)", "legendFormat": "{{service}} {{topic}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    }
+  ]
+}

--- a/docker/observability/grafana/provisioning/dashboards/json/vellumhub-overview.json
+++ b/docker/observability/grafana/provisioning/dashboards/json/vellumhub-overview.json
@@ -1,0 +1,210 @@
+{
+  "uid": "vellumhub-overview",
+  "title": "VellumHub Overview",
+  "tags": ["vellumhub", "overview", "observability"],
+  "timezone": "browser",
+  "schemaVersion": 41,
+  "version": 1,
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "links": [
+    { "title": "Runbooks", "url": "docs/OBSERVABILITY_RUNBOOKS.md", "targetBlank": true }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "label": "Service",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(up{job=~\".*-service\"}, job)",
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "current": { "selected": true, "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Application Targets UP",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum(up{job=~\".*-service\"})", "instant": true }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 4 },
+              { "color": "green", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "colorMode": "background" }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Gateway 5xx Ratio",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(http_server_requests_seconds_count{job=\"gateway-service\",status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{job=\"gateway-service\"}[5m])), 0.001)",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.02 },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "DLT Events",
+      "description": "Uses custom metrics when available; otherwise stays at 0 until #210 adds counters.",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum(increase(vellumhub_kafka_dlt_events_total[15m])) or vector(0)", "instant": true }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Empty Recommendations",
+      "description": "Future business metric from #210.",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum(increase(vellumhub_recommendation_empty_results_total[15m])) or vector(0)", "instant": true }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Requests by Service",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"$service\"}[5m]))",
+          "legendFormat": "{{job}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "HTTP p95 / p99 by Service",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le, job) (rate(http_server_requests_seconds_bucket{job=~\"$service\"}[5m]))) or max by (job) (http_server_requests_seconds_max{job=~\"$service\"})",
+          "legendFormat": "p95 {{job}}"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.99, sum by (le, job) (rate(http_server_requests_seconds_bucket{job=~\"$service\"}[5m])))",
+          "legendFormat": "p99 {{job}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "5xx by Service",
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"$service\",status=~\"5..\"}[5m]))", "legendFormat": "{{job}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Kafka and DLT Signals",
+      "description": "Shows business Kafka counters after #210; until then only custom metrics that exist will appear.",
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(vellumhub_kafka_producer_events_total[5m])) or vector(0)", "legendFormat": "published" },
+        { "refId": "B", "expr": "sum(rate(vellumhub_kafka_consumer_events_total[5m])) or vector(0)", "legendFormat": "consumed" },
+        { "refId": "C", "expr": "sum(rate(vellumhub_kafka_dlt_events_total[5m])) or vector(0)", "legendFormat": "dlt" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 9,
+      "type": "logs",
+      "title": "Recent Errors from Loki",
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 12 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        { "refId": "A", "expr": "{environment=\"local\", level=\"ERROR\"}" }
+      ],
+      "options": { "showLabels": true, "showTime": true, "wrapLogMessage": true }
+    }
+  ]
+}

--- a/docker/observability/grafana/provisioning/dashboards/json/vellumhub-recommendation-health.json
+++ b/docker/observability/grafana/provisioning/dashboards/json/vellumhub-recommendation-health.json
@@ -1,0 +1,91 @@
+{
+  "uid": "vellumhub-recommendation-health",
+  "title": "Recommendation Health",
+  "tags": ["vellumhub", "recommendation"],
+  "timezone": "browser",
+  "schemaVersion": 41,
+  "version": 1,
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Recommendation HTTP Requests",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (uri, status) (rate(http_server_requests_seconds_count{job=\"recommendation-service\"}[5m]))", "legendFormat": "{{status}} {{uri}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Recommendation Latency",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "histogram_quantile(0.95, sum by (le, uri) (rate(http_server_requests_seconds_bucket{job=\"recommendation-service\"}[5m]))) or max by (uri) (http_server_requests_seconds_max{job=\"recommendation-service\"})", "legendFormat": "p95 {{uri}}" },
+        { "refId": "B", "expr": "histogram_quantile(0.99, sum by (le, uri) (rate(http_server_requests_seconds_bucket{job=\"recommendation-service\"}[5m])))", "legendFormat": "p99 {{uri}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Generated, Empty, and Popularity Fallback Results",
+      "description": "Future business metrics from #210.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(vellumhub_recommendations_generated_total[5m])) or vector(0)", "legendFormat": "generated" },
+        { "refId": "B", "expr": "sum(rate(vellumhub_recommendation_empty_results_total[5m])) or vector(0)", "legendFormat": "empty" },
+        { "refId": "C", "expr": "sum(rate(vellumhub_recommendation_popularity_fallback_total[5m])) or vector(0)", "legendFormat": "popularity fallback" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "eps" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Recommendation Generation Duration",
+      "description": "Future timer metric from #210.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(vellumhub_recommendation_generation_seconds_sum[5m])) / clamp_min(sum(rate(vellumhub_recommendation_generation_seconds_count[5m])), 0.001) or vector(0)", "legendFormat": "avg generation" },
+        { "refId": "B", "expr": "histogram_quantile(0.95, sum by (le) (rate(vellumhub_recommendation_generation_seconds_bucket[5m]))) or vector(0)", "legendFormat": "p95 generation" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 5,
+      "type": "logs",
+      "title": "Recommendation Errors",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        { "refId": "A", "expr": "{service=\"recommendation-service\", level=\"ERROR\"}" }
+      ],
+      "options": { "showLabels": true, "showTime": true, "wrapLogMessage": true }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Recommendation DB Pool",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "hikaricp_connections_active{job=\"recommendation-service\"}", "legendFormat": "active" },
+        { "refId": "B", "expr": "hikaricp_connections_idle{job=\"recommendation-service\"}", "legendFormat": "idle" },
+        { "refId": "C", "expr": "hikaricp_connections_pending{job=\"recommendation-service\"}", "legendFormat": "pending" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    }
+  ]
+}

--- a/docker/observability/grafana/provisioning/dashboards/json/vellumhub-services-jvm-db.json
+++ b/docker/observability/grafana/provisioning/dashboards/json/vellumhub-services-jvm-db.json
@@ -1,0 +1,106 @@
+{
+  "uid": "vellumhub-services-jvm-db",
+  "title": "Services JVM and DB",
+  "tags": ["vellumhub", "jvm", "database"],
+  "timezone": "browser",
+  "schemaVersion": 41,
+  "version": 1,
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "label": "Service",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(up{job=~\".*-service\"}, job)",
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "current": { "selected": true, "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Heap Usage",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (job) (jvm_memory_used_bytes{job=~\"$service\",area=\"heap\"})", "legendFormat": "used {{job}}" },
+        { "refId": "B", "expr": "sum by (job) (jvm_memory_max_bytes{job=~\"$service\",area=\"heap\"})", "legendFormat": "max {{job}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "CPU Usage",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "process_cpu_usage{job=~\"$service\"}", "legendFormat": "process {{job}}" },
+        { "refId": "B", "expr": "system_cpu_usage{job=~\"$service\"}", "legendFormat": "system {{job}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "GC Pause Rate and Max",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (job) (rate(jvm_gc_pause_seconds_count{job=~\"$service\"}[5m]))", "legendFormat": "pauses/s {{job}}" },
+        { "refId": "B", "expr": "max by (job) (jvm_gc_pause_seconds_max{job=~\"$service\"})", "legendFormat": "max {{job}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Threads",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "jvm_threads_live_threads{job=~\"$service\"}", "legendFormat": "live {{job}}" },
+        { "refId": "B", "expr": "jvm_threads_daemon_threads{job=~\"$service\"}", "legendFormat": "daemon {{job}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Hikari Pool Active / Idle / Pending",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (job) (hikaricp_connections_active{job=~\"$service\"})", "legendFormat": "active {{job}}" },
+        { "refId": "B", "expr": "sum by (job) (hikaricp_connections_idle{job=~\"$service\"})", "legendFormat": "idle {{job}}" },
+        { "refId": "C", "expr": "sum by (job) (hikaricp_connections_pending{job=~\"$service\"})", "legendFormat": "pending {{job}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Hikari Acquire Time",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (job) (rate(hikaricp_connections_acquire_seconds_sum{job=~\"$service\"}[5m])) / clamp_min(sum by (job) (rate(hikaricp_connections_acquire_seconds_count{job=~\"$service\"}[5m])), 0.001)", "legendFormat": "avg {{job}}" },
+        { "refId": "B", "expr": "max by (job) (hikaricp_connections_acquire_seconds_max{job=~\"$service\"})", "legendFormat": "max {{job}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    }
+  ]
+}

--- a/docker/observability/prometheus/prometheus.yml
+++ b/docker/observability/prometheus/prometheus.yml
@@ -2,6 +2,9 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
 scrape_configs:
   - job_name: gateway-service
     metrics_path: /actuator/prometheus

--- a/docker/observability/prometheus/rules/vellumhub-alerts.yml
+++ b/docker/observability/prometheus/rules/vellumhub-alerts.yml
@@ -1,0 +1,124 @@
+groups:
+  - name: vellumhub-initial-alerts
+    interval: 30s
+    rules:
+      - alert: GatewayUnavailable
+        expr: up{job="gateway-service"} == 0
+        for: 1m
+        labels:
+          severity: P1
+          service: gateway-service
+        annotations:
+          summary: "Gateway is unavailable to Prometheus."
+          description: "Prometheus cannot scrape gateway-service for at least one minute."
+          runbook: "docs/OBSERVABILITY_RUNBOOKS.md#gateway-unavailable-or-5xx-high"
+
+      - alert: PrometheusTargetDown
+        expr: up{job=~".*-service"} == 0
+        for: 2m
+        labels:
+          severity: P2
+        annotations:
+          summary: "A VellumHub application target is down."
+          description: "Prometheus target {{ $labels.job }} is down."
+          runbook: "docs/OBSERVABILITY_RUNBOOKS.md#prometheus-target-down"
+
+      - alert: GatewayHigh5xxRate
+        expr: |
+          sum(rate(http_server_requests_seconds_count{job="gateway-service",status=~"5.."}[5m]))
+          /
+          clamp_min(sum(rate(http_server_requests_seconds_count{job="gateway-service"}[5m])), 0.001)
+          > 0.05
+        for: 5m
+        labels:
+          severity: P1
+          service: gateway-service
+        annotations:
+          summary: "Gateway 5xx ratio is above 5%."
+          description: "Gateway is returning a sustained elevated 5xx ratio."
+          runbook: "docs/OBSERVABILITY_RUNBOOKS.md#gateway-unavailable-or-5xx-high"
+
+      - alert: GatewayHighP95Latency
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (rate(http_server_requests_seconds_bucket{job="gateway-service"}[5m]))
+          ) > 2
+        for: 10m
+        labels:
+          severity: P2
+          service: gateway-service
+        annotations:
+          summary: "Gateway p95 latency is above 2 seconds."
+          description: "Gateway request latency stayed above the initial conservative threshold."
+          runbook: "docs/OBSERVABILITY_RUNBOOKS.md#gateway-unavailable-or-5xx-high"
+
+      - alert: HikariPendingConnections
+        expr: sum by (job) (hikaricp_connections_pending{job=~".*-service"}) > 0
+        for: 5m
+        labels:
+          severity: P2
+        annotations:
+          summary: "Hikari pending connections detected."
+          description: "Service {{ $labels.job }} has sustained pending database connections."
+          runbook: "docs/OBSERVABILITY_RUNBOOKS.md#database-saturated-or-hikari-exhausted"
+
+      - alert: JvmHeapNearLimit
+        expr: |
+          (
+            sum by (job) (jvm_memory_used_bytes{job=~".*-service",area="heap"})
+            /
+            clamp_min(sum by (job) (jvm_memory_max_bytes{job=~".*-service",area="heap"}), 1)
+          ) > 0.85
+        for: 10m
+        labels:
+          severity: P3
+        annotations:
+          summary: "JVM heap usage is near the configured maximum."
+          description: "Service {{ $labels.job }} is above 85% heap usage for a sustained period."
+          runbook: "docs/OBSERVABILITY_RUNBOOKS.md#database-saturated-or-hikari-exhausted"
+
+      - alert: KafkaDltEventsDetected
+        expr: increase(vellumhub_kafka_dlt_events_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: P1
+        annotations:
+          summary: "A Kafka event reached a Dead Letter Topic."
+          description: "DLT events were observed in the last five minutes."
+          runbook: "docs/OBSERVABILITY_RUNBOOKS.md#event-sent-to-dlt"
+
+      - alert: KafkaConsumerLagHigh
+        expr: max by (job) (kafka_consumer_fetch_manager_records_lag_max{job=~".*-service"}) > 1000
+        for: 10m
+        labels:
+          severity: P2
+        annotations:
+          summary: "Kafka consumer lag is above the initial threshold."
+          description: "Service {{ $labels.job }} has Kafka consumer lag above 1000."
+          runbook: "docs/OBSERVABILITY_RUNBOOKS.md#kafka-consumer-lag-high"
+
+      - alert: KafkaPublishFailures
+        expr: increase(vellumhub_kafka_producer_failures_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: P2
+        annotations:
+          summary: "Kafka publish failures detected."
+          description: "One or more Kafka publish failures were counted in the last five minutes."
+          runbook: "docs/OBSERVABILITY_RUNBOOKS.md#kafka-consumer-lag-high"
+
+      - alert: RecommendationEmptyResultsHigh
+        expr: |
+          sum(rate(vellumhub_recommendation_empty_results_total[10m]))
+          /
+          clamp_min(sum(rate(vellumhub_recommendation_requests_total[10m])), 0.001)
+          > 0.30
+        for: 15m
+        labels:
+          severity: P2
+          service: recommendation-service
+        annotations:
+          summary: "Recommendation empty-result ratio is high."
+          description: "More than 30% of recommendation requests returned empty results."
+          runbook: "docs/OBSERVABILITY_RUNBOOKS.md#recommendation-slow-or-empty"

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -40,6 +40,29 @@ Grafana datasources are provisioned from `docker/observability/grafana/provision
 - `Loki`
 - `Tempo`
 
+## Dashboards
+
+Grafana dashboards are provisioned automatically from `docker/observability/grafana/provisioning/dashboards/`.
+
+Provisioned dashboards:
+
+- `VellumHub Overview`
+- `Gateway and HTTP`
+- `Services JVM and DB`
+- `Kafka Flow`
+- `Recommendation Health`
+
+The dashboards use the provisioned `Prometheus`, `Loki`, and `Tempo` datasources. Panels based on metrics that are not implemented yet, such as custom Kafka/business counters from `#210`, use tolerant queries and remain empty or zero until those metrics exist.
+
+Validate dashboards locally:
+
+```bash
+docker compose --profile observability up -d grafana prometheus loki tempo alloy
+curl -u admin:admin http://localhost:3002/api/search?folderIds=0
+```
+
+Open `http://localhost:3002/dashboards` and select the `VellumHub` folder.
+
 ## Metrics
 
 Prometheus scrapes these targets on the Docker network:
@@ -55,6 +78,33 @@ Validate target health in Prometheus:
 1. Open `http://localhost:9090/targets`.
 2. Confirm the jobs `gateway-service`, `user-service`, `catalog-service`, `engagement-service`, and `recommendation-service` are present.
 3. When the application services are healthy, each target should show `UP`.
+
+## Alerts
+
+Initial alert rules are versioned in `docker/observability/prometheus/rules/vellumhub-alerts.yml` and loaded by Prometheus through `rule_files`.
+
+The initial rules are conservative local-development defaults:
+
+- `GatewayUnavailable` (`P1`)
+- `GatewayHigh5xxRate` (`P1`)
+- `GatewayHighP95Latency` (`P2`)
+- `PrometheusTargetDown` (`P2`)
+- `HikariPendingConnections` (`P2`)
+- `JvmHeapNearLimit` (`P3`)
+- `KafkaDltEventsDetected` (`P1`)
+- `KafkaConsumerLagHigh` (`P2`)
+- `KafkaPublishFailures` (`P2`)
+- `RecommendationEmptyResultsHigh` (`P2`)
+
+Validate alert rules locally:
+
+```bash
+docker compose --profile observability config
+curl http://localhost:9090/api/v1/rules
+curl http://localhost:9090/alerts
+```
+
+Each alert annotation points to [OBSERVABILITY_RUNBOOKS.md](OBSERVABILITY_RUNBOOKS.md). Alerts for future metrics remain inactive until those metrics are emitted.
 
 ## Logs
 
@@ -148,9 +198,13 @@ The expected behavior is:
 | File | Purpose |
 |---|---|
 | `docker/observability/prometheus/prometheus.yml` | Prometheus scrape jobs. |
+| `docker/observability/prometheus/rules/vellumhub-alerts.yml` | Initial local alert rules. |
 | `docker/observability/grafana/provisioning/datasources/datasources.yml` | Grafana datasource provisioning. |
+| `docker/observability/grafana/provisioning/dashboards/dashboards.yml` | Grafana dashboard provider. |
+| `docker/observability/grafana/provisioning/dashboards/json/*.json` | Provisioned Grafana dashboards. |
 | `docker/observability/loki/loki.yml` | Local single-node Loki storage. |
 | `docker/observability/tempo/tempo.yml` | Local Tempo trace storage and OTLP receiver config. |
 | `docker/observability/alloy/config.alloy` | Docker log collection, Loki forwarding, and OTLP-to-Tempo forwarding. |
+| `docs/OBSERVABILITY_RUNBOOKS.md` | Operational investigation guides linked from alerts. |
 
-Dashboards, alerts, business metrics, and manual domain spans are intentionally outside this issue.
+Business metrics and manual domain spans are intentionally outside this issue.

--- a/docs/OBSERVABILITY_RUNBOOKS.md
+++ b/docs/OBSERVABILITY_RUNBOOKS.md
@@ -1,0 +1,161 @@
+# Observability Runbooks
+
+These runbooks are initial local-development guides for the VellumHub observability stack. Thresholds are intentionally conservative and should be tuned after real traffic baselines exist.
+
+## Gateway Unavailable Or 5xx High
+
+**Symptom:** `GatewayUnavailable`, `GatewayHigh5xxRate`, or `GatewayHighP95Latency` fires. Users may see failed requests or slow API responses at `localhost:8080`.
+
+**Impact:** The gateway is the public entry point, so a gateway outage or high 5xx ratio can affect every user-facing workflow.
+
+**Look First:** Open `VellumHub Overview` for target health and 5xx by service, then `Gateway and HTTP` for route, status, latency, rate-limit signals, and gateway error logs.
+
+**Useful Commands:**
+
+```bash
+docker compose ps gateway-service redis-gateway
+docker compose logs --tail=200 gateway-service redis-gateway
+curl http://localhost:8080/actuator/health
+curl http://localhost:9090/api/v1/query?query=up%7Bjob%3D%22gateway-service%22%7D
+```
+
+**Likely Causes:** Gateway container restart loop, Redis unavailable for rate limiting, downstream service unavailable, invalid JWT configuration, route mismatch, or database/Kafka pressure surfacing through downstream responses.
+
+**First Actions:** Confirm gateway health, check recent gateway `ERROR` logs in Loki, identify whether 5xx is concentrated on a single route, then inspect the downstream service shown by the route.
+
+**Escalate When:** Gateway cannot start after a rebuild, multiple services are failing simultaneously, or traces show repeated failures across gateway and downstream services.
+
+## Recommendation Slow Or Empty
+
+**Symptom:** `RecommendationEmptyResultsHigh` fires, recommendation routes are slow, or users receive empty recommendation responses.
+
+**Impact:** Discovery quality drops and cold-start users may not receive useful book suggestions.
+
+**Look First:** Open `Recommendation Health` for recommendation HTTP latency, empty-result counters when available, DB pool state, and recommendation-service errors.
+
+**Useful Commands:**
+
+```bash
+docker compose ps recommendation-service postgres-recommendation kafka
+docker compose logs --tail=200 recommendation-service
+curl http://localhost:9090/api/v1/query?query=up%7Bjob%3D%22recommendation-service%22%7D
+```
+
+**Likely Causes:** Missing projection data from Kafka, pgvector query slowness, exhausted Hikari pool, embedding/profile data drift, or future business metrics not yet instrumented.
+
+**First Actions:** Check recommendation-service health, DB pool pending connections, recommendation errors, and Kafka Flow for missed or failed consumer signals. If business metrics are absent, inspect logs and Kafka UI.
+
+**Escalate When:** Empty results persist after Kafka consumers catch up, database queries remain slow, or user/profile/book projection data appears corrupted.
+
+## Kafka Consumer Lag High
+
+**Symptom:** `KafkaConsumerLagHigh` fires or Kafka UI shows consumer groups falling behind.
+
+**Impact:** Engagement, catalog, and preference events may not update recommendation or engagement projections quickly.
+
+**Look First:** Open `Kafka Flow` for consumer lag, consumed-event counters, failure counters, and DLT logs. Use Kafka UI at `http://localhost:8090` for topic and group details.
+
+**Useful Commands:**
+
+```bash
+docker compose ps kafka zookeeper recommendation-service engagement-service
+docker exec kafka kafka-consumer-groups --bootstrap-server kafka:29092 --all-groups --describe
+docker compose logs --tail=200 recommendation-service engagement-service kafka
+```
+
+**Likely Causes:** Consumer restart loop, poison event retries, topic contract drift, slow database writes, Kafka broker pressure, or metrics not yet exposed for some consumer groups.
+
+**First Actions:** Identify the lagging group/topic, compare service logs with Kafka UI, inspect retry/DLT logs, and check Hikari pending connections for the consumer service.
+
+**Escalate When:** Lag grows after restart, DLT entries increase, or topic contract mismatches are suspected.
+
+## Event Sent To DLT
+
+**Symptom:** `KafkaDltEventsDetected` fires or Loki query `{environment="local"} |= "DLT"` returns recent events.
+
+**Impact:** Some state transition failed after retries. Recommendation or engagement projections may be stale for the affected entity.
+
+**Look First:** Open `Kafka Flow`, especially `DLT Logs` and `DLT Metrics`. Then inspect the service-specific error logs.
+
+**Useful Commands:**
+
+```bash
+docker compose logs --tail=200 engagement-service recommendation-service
+docker exec kafka kafka-topics --bootstrap-server kafka:29092 --list
+docker exec kafka kafka-console-consumer --bootstrap-server kafka:29092 --topic <topic-name>-dlt --from-beginning --max-messages 5
+```
+
+**Likely Causes:** Invalid event shape, schema/topic drift, missing referenced entity, database constraint failure, or an application bug in the consumer.
+
+**First Actions:** Capture original topic, DLT topic, exception message, event type, and entity IDs from logs. Avoid dumping full payloads into issue comments or logs.
+
+**Escalate When:** The same event type repeatedly reaches DLT, DLT volume increases, or replay would require manual data repair.
+
+## Database Saturated Or Hikari Exhausted
+
+**Symptom:** `HikariPendingConnections` or `JvmHeapNearLimit` fires, DB-backed routes slow down, or service logs mention connection acquisition timeouts.
+
+**Impact:** Reads/writes may slow down or fail across catalog, user, engagement, or recommendation workflows.
+
+**Look First:** Open `Services JVM and DB` for Hikari active/idle/pending, acquire time, heap, GC, and CPU. Cross-check `Recommendation Health` for recommendation-specific DB pool pressure.
+
+**Useful Commands:**
+
+```bash
+docker compose ps postgres-user postgres-catalog postgres-engagement postgres-recommendation
+docker compose logs --tail=200 user-service catalog-service engagement-service recommendation-service
+docker compose logs --tail=100 postgres-user postgres-catalog postgres-engagement postgres-recommendation
+```
+
+**Likely Causes:** Slow SQL, migration issue, too many concurrent requests, exhausted pool size, PostgreSQL restart, or memory pressure causing long pauses.
+
+**First Actions:** Identify which service has pending connections, check DB container health, inspect recent service errors, and compare request latency with Hikari acquire time.
+
+**Escalate When:** Pending connections persist, PostgreSQL restarts, Flyway fails, or heap/GC pressure remains high after traffic drops.
+
+## Prometheus Target Down
+
+**Symptom:** `PrometheusTargetDown` fires or `VellumHub Overview` shows fewer than five application targets UP.
+
+**Impact:** Metrics for the affected service are missing; the service may also be unavailable.
+
+**Look First:** Open `VellumHub Overview`, then Prometheus `http://localhost:9090/targets`.
+
+**Useful Commands:**
+
+```bash
+docker compose ps
+docker compose logs --tail=150 <service-name>
+curl http://localhost:9090/targets
+curl http://localhost:8080/actuator/health
+```
+
+**Likely Causes:** Service container unhealthy, wrong network/service name, Actuator endpoint not exposed, application startup failure, or Prometheus scrape config mismatch.
+
+**First Actions:** Confirm the container is running, inspect its healthcheck, call `/actuator/prometheus` from inside the Docker network if needed, and compare service names with `docker/observability/prometheus/prometheus.yml`.
+
+**Escalate When:** The service starts but Prometheus still cannot scrape it, or multiple services disappear at once.
+
+## Logs Missing In Loki
+
+**Symptom:** Grafana Explore or dashboard log panels show no logs for a service while Docker logs exist.
+
+**Impact:** Investigations lose structured log context and trace-to-logs navigation becomes weaker.
+
+**Look First:** Open `VellumHub Overview` recent errors, then Grafana Explore with `{environment="local"}` and `{service="<service-name>"}`.
+
+**Useful Commands:**
+
+```bash
+docker compose ps alloy loki
+docker compose logs --tail=200 alloy loki
+docker compose logs --tail=50 gateway-service user-service catalog-service engagement-service recommendation-service
+curl http://localhost:3100/ready
+curl http://localhost:12345/-/ready
+```
+
+**Likely Causes:** Alloy cannot read Docker socket, Loki is unhealthy, service logs are not JSON, service label extraction changed, or the container name is not covered by Alloy discovery.
+
+**First Actions:** Confirm Alloy and Loki readiness, check Alloy logs for Docker discovery errors, verify the app emits JSON logs, and compare container names with `docker/observability/alloy/config.alloy`.
+
+**Escalate When:** Loki receives no logs from any service, Alloy cannot access Docker socket, or labels are missing after a logging configuration change.


### PR DESCRIPTION
This pull request introduces initial observability dashboards and improvements for local monitoring, as well as a new database seeder for book genres in the catalog service. The most significant changes are the addition of Grafana dashboards for system metrics and Kafka flow, the introduction of a Prometheus rule directory, and the implementation (with tests) of a genre seeder for the catalog service.

**Observability and Monitoring Enhancements:**

* Added three initial Grafana dashboards for local development: an overview dashboard, a gateway/HTTP dashboard, and a Kafka flow dashboard, providing visibility into service health, HTTP metrics, Kafka events, and error logs (`docker/observability/grafana/provisioning/dashboards/json/vellumhub-overview.json`, `docker/observability/grafana/provisioning/dashboards/json/vellumhub-gateway-http.json`, `docker/observability/grafana/provisioning/dashboards/json/vellumhub-kafka-flow.json`) [[1]](diffhunk://#diff-6c890fb3a9994de9214fff1065004f4b2bff3837e156bf4bc3372b4082ad5341R1-R210) [[2]](diffhunk://#diff-895f26ec068de56baad05a3761acdef26c89b7ccac07ddfb24be6962f4190bd8R1-R86) [[3]](diffhunk://#diff-23d1cd5868b68c6f11ad328de42b5830095ab554a662dffd3256b8a1be93b238R1-R88).
* Added Grafana dashboard provisioning configuration to automatically load dashboards from disk (`docker/observability/grafana/provisioning/dashboards/dashboards.yml`).
* Updated Prometheus service in Docker Compose to mount a rules directory, enabling local use of custom Prometheus alerting or recording rules (`docker-compose.yml`).

**Catalog Service Improvements:**

* Introduced `InitialGenreSeeder`, a Spring Boot component that seeds the database with a predefined list of book genres if they are missing, and added corresponding unit tests to verify correct behavior (`catalog-service/src/main/java/com/vellumhub/catalog_service/share/config/InitialGenreSeeder.java`, `catalog-service/src/test/java/com/vellumhub/catalog_service/share/config/InitialGenreSeederTest.java`) [[1]](diffhunk://#diff-756c0ea3ee37ae81b550f149f6b4bcb571e82e4b668dbba9e037a7efa153fe48R1-R50) [[2]](diffhunk://#diff-35a20cb681d12f682a5216beab1c326da3565ba5ea2191d7840ca290b7790229R1-R56).

**Documentation Updates:**

* Updated the observability documentation references in `README.md` to include operational incident runbooks (`README.md`).