### PR TITLE
#210 feat: enhance observability with Kafka metrics and restore tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It is written as a backend engineering reference project: the goal is not just t
 - [Kafka Event Contracts](#kafka-event-contracts)
 - [Gateway and Security](#gateway-and-security)
 - [Running Locally](#running-locally)
+- [Observability](#observability)
 - [Quality Evidence](#quality-evidence)
 - [Roadmap](#roadmap)
 
@@ -352,6 +353,33 @@ The gateway currently exposes Actuator endpoints, not a Springdoc UI, and its ro
 
 ## Observability
 
+VellumHub includes an optional local observability stack for development. It combines service metrics, structured logs, traces, dashboards, alerts, and runbooks so operational behavior can be inspected without external infrastructure.
+
+Enable it with the Docker Compose `observability` profile:
+
+```bash
+docker compose --profile observability up -d --build
+```
+
+Local observability endpoints:
+
+| Component | URL | Purpose |
+|---|---|---|
+| Prometheus | `http://localhost:9090` | Scrapes service metrics from `/actuator/prometheus`. |
+| Grafana | `http://localhost:3002` | Dashboards, Explore, and provisioned datasources. |
+| Loki | `http://localhost:3100` | Stores structured Docker logs collected by Alloy. |
+| Tempo | `http://localhost:3200` | Stores traces sent through Alloy. |
+| Alloy | `http://localhost:12345` | Collects Docker logs and forwards OTLP traces. |
+| Kafka UI | `http://localhost:8090` | Topic and consumer-group inspection. |
+
+Grafana is provisioned with Prometheus, Loki, and Tempo datasources plus these dashboards:
+
+- `VellumHub Overview`
+- `Gateway and HTTP`
+- `Services JVM and DB`
+- `Kafka Flow`
+- `Recommendation Health`
+
 Services expose Spring Boot Actuator endpoints:
 
 - `/actuator/health`
@@ -359,11 +387,44 @@ Services expose Spring Boot Actuator endpoints:
 - `/actuator/metrics`
 - `/actuator/prometheus`
 
-`/actuator/prometheus` is backed by the Micrometer Prometheus registry and exports metrics with a common `service` tag. Health remains publicly reachable for Docker healthchecks. The observability profile scrapes these endpoints through Prometheus, ships structured Docker logs to Loki, forwards OpenTelemetry Java Agent traces through Alloy to Tempo, and provisions Grafana with Prometheus, Loki, and Tempo datasources. Broader Actuator endpoints such as `info` and `metrics` still require authentication on the application services and gateway.
+`/actuator/prometheus` is backed by the Micrometer Prometheus registry and exports metrics with a common `service` tag. Prometheus scrapes the gateway, user, catalog, engagement, and recommendation services on the Docker network. Health remains publicly reachable for Docker healthchecks. Broader Actuator endpoints such as `info` and `metrics` still require authentication on the application services and gateway.
 
 In the `prod` profile, health details are hidden and the gateway lowers Spring Cloud Gateway logging from local `TRACE` diagnostics to `INFO`.
 
-Kafka UI is available at `http://localhost:8090` when the compose stack is running. The full local observability workflow is documented in [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md), operational incident guides live in [docs/OBSERVABILITY_RUNBOOKS.md](docs/OBSERVABILITY_RUNBOOKS.md), and additional Kafka monitoring notes live in [docs/KAFKA_MONITORING.md](docs/KAFKA_MONITORING.md), though the code-level topic inventory above is newer than parts of that document.
+### Custom Metrics
+
+Custom application metrics use the `vellumhub_*` Prometheus prefix. They keep labels intentionally low-cardinality: `service`, `topic`, `event_type`, `consumer_group`, `operation`, and `result`.
+
+Kafka and DLT metrics:
+
+- `vellumhub_kafka_events_published_total`
+- `vellumhub_kafka_events_publish_failed_total`
+- `vellumhub_kafka_events_consumed_total`
+- `vellumhub_kafka_events_consume_failed_total`
+- `vellumhub_kafka_event_processing_duration_seconds_count`
+- `vellumhub_kafka_event_processing_duration_seconds_sum`
+- `vellumhub_kafka_dlt_events_total`
+
+Business metrics:
+
+- `vellumhub_users_total`
+- `vellumhub_books_total`
+- `vellumhub_books_updated_total`
+- `vellumhub_books_deleted_total`
+- `vellumhub_reading_progress_updated_total`
+- `vellumhub_ratings_total`
+- `vellumhub_reactions_changed_total`
+- `vellumhub_recommendations_requested_total`
+- `vellumhub_recommendations_generated_total`
+- `vellumhub_recommendation_empty_results_total`
+- `vellumhub_recommendation_generation_duration_seconds_count`
+- `vellumhub_recommendation_generation_duration_seconds_sum`
+
+The Kafka metrics cover producer success/failure, consumer success/failure, processing duration, and DLT quarantine. Business metrics cover user registration/admin creation, catalog book lifecycle, reading progress updates, ratings, reactions, and recommendation generation. Recommendation metrics distinguish empty results from generated non-empty results.
+
+Structured logs flow from application containers to Loki through Alloy. DLT logs include original topic, DLT topic, exception message, and payload byte length without printing raw Kafka payloads by default. Traces are emitted by the OpenTelemetry Java Agent and forwarded through Alloy to Tempo; metrics and logs intentionally stay on the Micrometer/Prometheus and Docker-log/Loki paths.
+
+The full local observability workflow is documented in [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md), operational incident guides live in [docs/OBSERVABILITY_RUNBOOKS.md](docs/OBSERVABILITY_RUNBOOKS.md), and additional Kafka monitoring notes live in [docs/KAFKA_MONITORING.md](docs/KAFKA_MONITORING.md), though the code-level topic inventory above is newer than parts of that document.
 
 ## Quality Evidence
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -95,18 +95,20 @@ Kafka metrics:
 
 Business metrics:
 
-- `vellumhub_users_created_total`
-- `vellumhub_books_created_total`
+- `vellumhub_users_total` (`operation=user_registration|admin_user_creation`)
+- `vellumhub_books_total` (`operation=book_creation`)
 - `vellumhub_books_updated_total`
 - `vellumhub_books_deleted_total`
 - `vellumhub_reading_progress_updated_total`
-- `vellumhub_ratings_created_total`
+- `vellumhub_ratings_total` (`operation=rating_creation`)
 - `vellumhub_reactions_changed_total`
 - `vellumhub_recommendations_requested_total`
 - `vellumhub_recommendations_generated_total`
 - `vellumhub_recommendation_empty_results_total`
 - `vellumhub_recommendation_generation_duration_seconds_count`
 - `vellumhub_recommendation_generation_duration_seconds_sum`
+
+Prometheus reserves metric-family names ending in `_created`, so Micrometer counters named `vellumhub.users.created`, `vellumhub.books.created`, and `vellumhub.ratings.created` export without that reserved suffix. Use the `operation` label to distinguish the creation flows.
 
 Custom metric labels are intentionally low-cardinality. The `service` label comes from each service's `management.metrics.tags.service` configuration. Kafka metrics also use `topic`, `event_type`, `consumer_group`, and `result` where applicable. Business metrics use `operation` and `result`.
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -52,7 +52,7 @@ Provisioned dashboards:
 - `Kafka Flow`
 - `Recommendation Health`
 
-The dashboards use the provisioned `Prometheus`, `Loki`, and `Tempo` datasources. Panels based on metrics that are not implemented yet, such as custom Kafka/business counters from `#210`, use tolerant queries and remain empty or zero until those metrics exist.
+The dashboards use the provisioned `Prometheus`, `Loki`, and `Tempo` datasources. Panels based on custom Kafka and business metrics use tolerant queries and remain empty or zero until local traffic emits those series.
 
 Validate dashboards locally:
 
@@ -79,6 +79,46 @@ Validate target health in Prometheus:
 2. Confirm the jobs `gateway-service`, `user-service`, `catalog-service`, `engagement-service`, and `recommendation-service` are present.
 3. When the application services are healthy, each target should show `UP`.
 
+### Custom Kafka And Business Metrics
+
+Issue `#210` adds custom Micrometer metrics in `user-service`, `catalog-service`, `engagement-service`, and `recommendation-service`. Micrometer dotted names are exported by Prometheus with underscores and counter suffixes.
+
+Kafka metrics:
+
+- `vellumhub_kafka_events_published_total`
+- `vellumhub_kafka_events_publish_failed_total`
+- `vellumhub_kafka_events_consumed_total`
+- `vellumhub_kafka_events_consume_failed_total`
+- `vellumhub_kafka_event_processing_duration_seconds_count`
+- `vellumhub_kafka_event_processing_duration_seconds_sum`
+- `vellumhub_kafka_dlt_events_total`
+
+Business metrics:
+
+- `vellumhub_users_created_total`
+- `vellumhub_books_created_total`
+- `vellumhub_books_updated_total`
+- `vellumhub_books_deleted_total`
+- `vellumhub_reading_progress_updated_total`
+- `vellumhub_ratings_created_total`
+- `vellumhub_reactions_changed_total`
+- `vellumhub_recommendations_requested_total`
+- `vellumhub_recommendations_generated_total`
+- `vellumhub_recommendation_empty_results_total`
+- `vellumhub_recommendation_generation_duration_seconds_count`
+- `vellumhub_recommendation_generation_duration_seconds_sum`
+
+Custom metric labels are intentionally low-cardinality. The `service` label comes from each service's `management.metrics.tags.service` configuration. Kafka metrics also use `topic`, `event_type`, `consumer_group`, and `result` where applicable. Business metrics use `operation` and `result`.
+
+Useful Prometheus API checks after generating local traffic:
+
+```bash
+curl "http://localhost:9090/api/v1/query?query=vellumhub_kafka_events_published_total"
+curl "http://localhost:9090/api/v1/query?query=vellumhub_kafka_dlt_events_total"
+curl "http://localhost:9090/api/v1/query?query=vellumhub_recommendations_generated_total"
+curl "http://localhost:9090/api/v1/query?query=vellumhub_recommendation_generation_duration_seconds_count"
+```
+
 ## Alerts
 
 Initial alert rules are versioned in `infra/observability/prometheus/rules/vellumhub-alerts.yml` and loaded by Prometheus through `rule_files`.
@@ -104,7 +144,7 @@ curl http://localhost:9090/api/v1/rules
 curl http://localhost:9090/alerts
 ```
 
-Each alert annotation points to [OBSERVABILITY_RUNBOOKS.md](OBSERVABILITY_RUNBOOKS.md). Alerts for future metrics remain inactive until those metrics are emitted.
+Each alert annotation points to [OBSERVABILITY_RUNBOOKS.md](OBSERVABILITY_RUNBOOKS.md). Custom-metric alerts remain inactive until local traffic emits the relevant series.
 
 ## Logs
 
@@ -207,4 +247,4 @@ The expected behavior is:
 | `infra/observability/alloy/config.alloy` | Docker log collection, Loki forwarding, and OTLP-to-Tempo forwarding. |
 | `docs/OBSERVABILITY_RUNBOOKS.md` | Operational investigation guides linked from alerts. |
 
-Business metrics and manual domain spans are intentionally outside this issue.
+Manual domain spans remain outside this issue; metrics continue to use Prometheus/Micrometer.

--- a/docs/OBSERVABILITY_RUNBOOKS.md
+++ b/docs/OBSERVABILITY_RUNBOOKS.md
@@ -41,7 +41,7 @@ docker compose logs --tail=200 recommendation-service
 curl http://localhost:9090/api/v1/query?query=up%7Bjob%3D%22recommendation-service%22%7D
 ```
 
-**Likely Causes:** Missing projection data from Kafka, pgvector query slowness, exhausted Hikari pool, embedding/profile data drift, or future business metrics not yet instrumented.
+**Likely Causes:** Missing projection data from Kafka, pgvector query slowness, exhausted Hikari pool, embedding/profile data drift, or no local traffic emitted for the recommendation business metrics yet.
 
 **First Actions:** Check recommendation-service health, DB pool pending connections, recommendation errors, and Kafka Flow for missed or failed consumer signals. If business metrics are absent, inspect logs and Kafka UI.
 

--- a/services/catalog-service/pom.xml
+++ b/services/catalog-service/pom.xml
@@ -146,6 +146,21 @@
 					<source>21</source>
 					<target>21</target>
 				</configuration>
+				<executions>
+					<execution>
+						<id>default-testCompile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+						<configuration>
+							<compileSourceRoots>
+								<compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
+								<compileSourceRoot>${project.basedir}/src/test/java</compileSourceRoot>
+							</compileSourceRoots>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/services/catalog-service/src/main/java/com/vellumhub/catalog_service/module/book/domain/handler/CreateBookHandler.java
+++ b/services/catalog-service/src/main/java/com/vellumhub/catalog_service/module/book/domain/handler/CreateBookHandler.java
@@ -9,6 +9,7 @@ import com.vellumhub.catalog_service.module.book.domain.port.BookRepository;
 import com.vellumhub.catalog_service.module.book.domain.port.GenreRepository;
 import com.vellumhub.catalog_service.module.book.domain.event.CreateBookEvent;
 import com.vellumhub.catalog_service.module.book_request.domain.exception.BookRequestDomainException;
+import com.vellumhub.catalog_service.share.metrics.VellumHubMetrics;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,14 +22,17 @@ public class CreateBookHandler {
     private final BookRepository bookRepository;
     private final GenreRepository genreRepository;
     private final BookEventProducer<String, CreateBookEvent> bookEventProducer;
+    private final VellumHubMetrics metrics;
 
     public CreateBookHandler(
             BookRepository bookRepository,
             GenreRepository genreRepository,
-            BookEventProducer<String, CreateBookEvent> bookEventProducer) {
+            BookEventProducer<String, CreateBookEvent> bookEventProducer,
+            VellumHubMetrics metrics) {
         this.bookRepository = bookRepository;
         this.genreRepository = genreRepository;
         this.bookEventProducer = bookEventProducer;
+        this.metrics = metrics;
     }
 
     @Transactional
@@ -54,6 +58,7 @@ public class CreateBookHandler {
         bookRepository.save(book);
 
         publishEvent(book);
+        metrics.recordBusinessCounter(VellumHubMetrics.BOOKS_CREATED, "book_creation", "success");
     }
 
     private void verifyUniquenessPolicy(CreateBookCommand command) {

--- a/services/catalog-service/src/main/java/com/vellumhub/catalog_service/module/book/domain/handler/DeleteBookHandler.java
+++ b/services/catalog-service/src/main/java/com/vellumhub/catalog_service/module/book/domain/handler/DeleteBookHandler.java
@@ -4,6 +4,7 @@ import com.vellumhub.catalog_service.module.book.domain.event.DeleteBookEvent;
 import com.vellumhub.catalog_service.module.book.domain.exception.BookNotExistException;
 import com.vellumhub.catalog_service.module.book.domain.port.BookEventProducer;
 import com.vellumhub.catalog_service.module.book.domain.port.BookRepository;
+import com.vellumhub.catalog_service.share.metrics.VellumHubMetrics;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,10 +15,12 @@ public class DeleteBookHandler {
 
     private final BookRepository bookRepository;
     private final BookEventProducer<String, DeleteBookEvent> bookEventProducer;
+    private final VellumHubMetrics metrics;
 
-    public DeleteBookHandler(BookRepository bookRepository, BookEventProducer<String, DeleteBookEvent> bookEventProducer) {
+    public DeleteBookHandler(BookRepository bookRepository, BookEventProducer<String, DeleteBookEvent> bookEventProducer, VellumHubMetrics metrics) {
         this.bookRepository = bookRepository;
         this.bookEventProducer = bookEventProducer;
+        this.metrics = metrics;
     }
 
     @Transactional
@@ -29,6 +32,7 @@ public class DeleteBookHandler {
         DeleteBookEvent deleteMediaEvent = new DeleteBookEvent(bookId);
 
         bookEventProducer.send("deleted-book", bookId.toString(), deleteMediaEvent);
+        metrics.recordBusinessCounter(VellumHubMetrics.BOOKS_DELETED, "book_deletion", "success");
     }
 
 

--- a/services/catalog-service/src/main/java/com/vellumhub/catalog_service/module/book/domain/handler/UpdateBookHandler.java
+++ b/services/catalog-service/src/main/java/com/vellumhub/catalog_service/module/book/domain/handler/UpdateBookHandler.java
@@ -10,6 +10,7 @@ import com.vellumhub.catalog_service.module.book.domain.model.Book;
 import com.vellumhub.catalog_service.module.book.domain.port.BookEventProducer;
 import com.vellumhub.catalog_service.module.book.domain.port.BookRepository;
 import com.vellumhub.catalog_service.module.book_request.domain.exception.BookRequestDomainException;
+import com.vellumhub.catalog_service.share.metrics.VellumHubMetrics;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,14 +24,17 @@ public class UpdateBookHandler {
     private final BookRepository bookRepository;
     private final GenreRepository genreRepository;
     private final BookEventProducer<String, UpdateBookEvent> bookEventProducer;
+    private final VellumHubMetrics metrics;
 
     public UpdateBookHandler(
             BookRepository bookRepository,
             GenreRepository genreRepository,
-            BookEventProducer<String, UpdateBookEvent> bookEventProducer) {
+            BookEventProducer<String, UpdateBookEvent> bookEventProducer,
+            VellumHubMetrics metrics) {
         this.bookRepository = bookRepository;
         this.genreRepository = genreRepository;
         this.bookEventProducer = bookEventProducer;
+        this.metrics = metrics;
     }
 
     /**
@@ -72,6 +76,7 @@ public class UpdateBookHandler {
         );
 
         bookEventProducer.send("updated-book", book.getId().toString(), updateBookEvent);
+        metrics.recordBusinessCounter(VellumHubMetrics.BOOKS_UPDATED, "book_update", "success");
     }
 
     /**

--- a/services/catalog-service/src/main/java/com/vellumhub/catalog_service/module/book/infrastructure/producer/KafkaBookEventProducer.java
+++ b/services/catalog-service/src/main/java/com/vellumhub/catalog_service/module/book/infrastructure/producer/KafkaBookEventProducer.java
@@ -1,11 +1,9 @@
 package com.vellumhub.catalog_service.module.book.infrastructure.producer;
 
 import com.vellumhub.catalog_service.module.book.domain.port.BookEventProducer;
+import com.vellumhub.catalog_service.share.metrics.VellumHubMetrics;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
@@ -17,9 +15,11 @@ import java.util.concurrent.CompletableFuture;
 public class KafkaBookEventProducer<K, V> implements BookEventProducer<K, V> {
 
     private final KafkaTemplate<K, V> kafkaTemplate;
+    private final VellumHubMetrics metrics;
 
-    public KafkaBookEventProducer(KafkaTemplate<K, V> kafkaTemplate) {
+    public KafkaBookEventProducer(KafkaTemplate<K, V> kafkaTemplate, VellumHubMetrics metrics) {
         this.kafkaTemplate = kafkaTemplate;
+        this.metrics = metrics;
     }
 
     @Override
@@ -30,6 +30,7 @@ public class KafkaBookEventProducer<K, V> implements BookEventProducer<K, V> {
 
         future.whenComplete((result, ex) -> {
             if (ex != null) {
+                metrics.recordKafkaPublishFailed(topic, value);
                 log.error(
                         "Failed to send event to Kafka — topic: {}, key: {}, reason: {}",
                         topic, key, ex.getMessage(), ex
@@ -37,6 +38,7 @@ public class KafkaBookEventProducer<K, V> implements BookEventProducer<K, V> {
                 handleSendFailure(topic, key, value, ex);
             } else {
                 RecordMetadata metadata = result.getRecordMetadata();
+                metrics.recordKafkaPublished(topic, value);
                 log.info(
                         "Event successfully sent to Kafka — topic: {}, partition: {}, offset: {}, key: {}",
                         metadata.topic(), metadata.partition(), metadata.offset(), key

--- a/services/catalog-service/src/main/java/com/vellumhub/catalog_service/module/book_progress/domain/use_case/UpdateBookProgressUseCase.java
+++ b/services/catalog-service/src/main/java/com/vellumhub/catalog_service/module/book_progress/domain/use_case/UpdateBookProgressUseCase.java
@@ -7,15 +7,18 @@ import com.vellumhub.catalog_service.module.book_progress.domain.exception.BookP
 import com.vellumhub.catalog_service.module.book_progress.domain.model.ReadingStatus;
 import com.vellumhub.catalog_service.module.book_progress.domain.port.BookProgressRepository;
 import com.vellumhub.catalog_service.module.book_progress.domain.model.BookProgress;
+import com.vellumhub.catalog_service.share.metrics.VellumHubMetrics;
 import org.springframework.stereotype.Component;
 
 @Component
 public class UpdateBookProgressUseCase {
 
      private final BookProgressRepository bookProgressRepository;
+     private final VellumHubMetrics metrics;
 
-     public UpdateBookProgressUseCase(BookProgressRepository bookProgressRepository) {
+     public UpdateBookProgressUseCase(BookProgressRepository bookProgressRepository, VellumHubMetrics metrics) {
           this.bookProgressRepository = bookProgressRepository;
+          this.metrics = metrics;
      }
 
      public UpdateBookProgressEvent execute(UpdateBookProgressCommand command){
@@ -31,6 +34,7 @@ public class UpdateBookProgressUseCase {
           bookProgress.update(bookProgress.getReadingStatus(), command.currentPage());
 
           bookProgressRepository.save(bookProgress);
+          metrics.recordBusinessCounter(VellumHubMetrics.READING_PROGRESS_UPDATED, "reading_progress_update", "success");
 
           return new UpdateBookProgressEvent(
                   bookProgress.getId(),

--- a/services/catalog-service/src/main/java/com/vellumhub/catalog_service/module/book_progress/infrastructure/producer/KafkaBookProgressEventProducer.java
+++ b/services/catalog-service/src/main/java/com/vellumhub/catalog_service/module/book_progress/infrastructure/producer/KafkaBookProgressEventProducer.java
@@ -1,6 +1,7 @@
 package com.vellumhub.catalog_service.module.book_progress.infrastructure.producer;
 
 import com.vellumhub.catalog_service.module.book_progress.domain.port.BookProgressEventProducer;
+import com.vellumhub.catalog_service.share.metrics.VellumHubMetrics;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -14,9 +15,11 @@ import java.util.concurrent.CompletableFuture;
 public class KafkaBookProgressEventProducer<K, V> implements BookProgressEventProducer<K, V> {
 
     private final KafkaTemplate<K, V> kafkaTemplate;
+    private final VellumHubMetrics metrics;
 
-    public KafkaBookProgressEventProducer(KafkaTemplate<K, V> kafkaTemplate) {
+    public KafkaBookProgressEventProducer(KafkaTemplate<K, V> kafkaTemplate, VellumHubMetrics metrics) {
         this.kafkaTemplate = kafkaTemplate;
+        this.metrics = metrics;
     }
 
     @Override
@@ -27,6 +30,7 @@ public class KafkaBookProgressEventProducer<K, V> implements BookProgressEventPr
 
         future.whenComplete((result, ex) -> {
             if (ex != null) {
+                metrics.recordKafkaPublishFailed(topic, value);
                 log.error(
                         "Failed to send event to Kafka — topic: {}, key: {}, reason: {}",
                         topic, key, ex.getMessage(), ex
@@ -34,6 +38,7 @@ public class KafkaBookProgressEventProducer<K, V> implements BookProgressEventPr
                 handleSendFailure(topic, key, value, ex);
             } else {
                 RecordMetadata metadata = result.getRecordMetadata();
+                metrics.recordKafkaPublished(topic, value);
                 log.info(
                         "Event successfully sent to Kafka — topic: {}, partition: {}, offset: {}, key: {}",
                         metadata.topic(), metadata.partition(), metadata.offset(), key

--- a/services/catalog-service/src/main/java/com/vellumhub/catalog_service/share/config/InitialGenreSeeder.java
+++ b/services/catalog-service/src/main/java/com/vellumhub/catalog_service/share/config/InitialGenreSeeder.java
@@ -2,6 +2,7 @@ package com.vellumhub.catalog_service.share.config;
 
 import com.vellumhub.catalog_service.module.book.domain.model.Genre;
 import com.vellumhub.catalog_service.module.book.infrastructure.repository.genre.JpaGenreRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
@@ -10,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Component
-class InitialGenreSeeder implements ApplicationRunner {
+public class InitialGenreSeeder implements ApplicationRunner {
 
     static final List<String> INITIAL_GENRES = List.of(
             "Science Fiction",
@@ -28,7 +29,8 @@ class InitialGenreSeeder implements ApplicationRunner {
     private final JpaGenreRepository genreRepository;
     private final List<String> initialGenres;
 
-    InitialGenreSeeder(JpaGenreRepository genreRepository) {
+    @Autowired
+    public InitialGenreSeeder(JpaGenreRepository genreRepository) {
         this(genreRepository, INITIAL_GENRES);
     }
 

--- a/services/catalog-service/src/main/java/com/vellumhub/catalog_service/share/metrics/VellumHubMetrics.java
+++ b/services/catalog-service/src/main/java/com/vellumhub/catalog_service/share/metrics/VellumHubMetrics.java
@@ -1,0 +1,89 @@
+package com.vellumhub.catalog_service.share.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class VellumHubMetrics {
+
+    public static final String KAFKA_EVENTS_PUBLISHED = "vellumhub.kafka.events.published";
+    public static final String KAFKA_EVENTS_PUBLISH_FAILED = "vellumhub.kafka.events.publish.failed";
+    public static final String KAFKA_EVENTS_CONSUMED = "vellumhub.kafka.events.consumed";
+    public static final String KAFKA_EVENTS_CONSUME_FAILED = "vellumhub.kafka.events.consume.failed";
+    public static final String KAFKA_EVENT_PROCESSING_DURATION = "vellumhub.kafka.event.processing.duration";
+    public static final String KAFKA_DLT_EVENTS = "vellumhub.kafka.dlt.events";
+
+    public static final String USERS_CREATED = "vellumhub.users.created";
+    public static final String BOOKS_CREATED = "vellumhub.books.created";
+    public static final String BOOKS_UPDATED = "vellumhub.books.updated";
+    public static final String BOOKS_DELETED = "vellumhub.books.deleted";
+    public static final String READING_PROGRESS_UPDATED = "vellumhub.reading.progress.updated";
+    public static final String RATINGS_CREATED = "vellumhub.ratings.created";
+    public static final String REACTIONS_CHANGED = "vellumhub.reactions.changed";
+    public static final String RECOMMENDATIONS_REQUESTED = "vellumhub.recommendations.requested";
+    public static final String RECOMMENDATIONS_GENERATED = "vellumhub.recommendations.generated";
+    public static final String RECOMMENDATION_EMPTY_RESULTS = "vellumhub.recommendation.empty.results";
+    public static final String RECOMMENDATION_GENERATION_DURATION = "vellumhub.recommendation.generation.duration";
+
+    private final MeterRegistry meterRegistry;
+
+    public VellumHubMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = Objects.requireNonNull(meterRegistry, "meterRegistry must not be null");
+    }
+
+    public void recordKafkaPublished(String topic, Object event) {
+        counter(KAFKA_EVENTS_PUBLISHED, "topic", topic, "event_type", eventType(event), "result", "success").increment();
+    }
+
+    public void recordKafkaPublishFailed(String topic, Object event) {
+        counter(KAFKA_EVENTS_PUBLISH_FAILED, "topic", topic, "event_type", eventType(event), "result", "failure").increment();
+    }
+
+    public Timer.Sample startKafkaProcessing() {
+        return Timer.start(meterRegistry);
+    }
+
+    public void recordKafkaConsumed(String topic, String eventType, String consumerGroup) {
+        counter(KAFKA_EVENTS_CONSUMED, "topic", topic, "event_type", eventType, "consumer_group", consumerGroup, "result", "success").increment();
+    }
+
+    public void recordKafkaConsumeFailed(String topic, String eventType, String consumerGroup) {
+        counter(KAFKA_EVENTS_CONSUME_FAILED, "topic", topic, "event_type", eventType, "consumer_group", consumerGroup, "result", "failure").increment();
+    }
+
+    public void recordKafkaProcessingDuration(Timer.Sample sample, String topic, String eventType, String consumerGroup, String result) {
+        sample.stop(Timer.builder(KAFKA_EVENT_PROCESSING_DURATION)
+                .tags("topic", topic, "event_type", eventType, "consumer_group", consumerGroup, "result", result)
+                .register(meterRegistry));
+    }
+
+    public void recordKafkaDlt(String originalTopic, String consumerGroup) {
+        counter(KAFKA_DLT_EVENTS, "topic", originalTopic, "event_type", "kafka_dlt", "consumer_group", consumerGroup, "operation", "kafka_dlt_quarantine", "result", "quarantined").increment();
+    }
+
+    public void recordBusinessCounter(String name, String operation, String result) {
+        counter(name, "operation", operation, "result", result).increment();
+    }
+
+    public Timer.Sample startBusinessTimer() {
+        return Timer.start(meterRegistry);
+    }
+
+    public void recordRecommendationGenerationDuration(Timer.Sample sample, String result) {
+        sample.stop(Timer.builder(RECOMMENDATION_GENERATION_DURATION)
+                .tags("operation", "recommendation_generation", "result", result)
+                .register(meterRegistry));
+    }
+
+    private Counter counter(String name, String... tags) {
+        return Counter.builder(name).tags(tags).register(meterRegistry);
+    }
+
+    private String eventType(Object event) {
+        return event == null ? "unknown" : event.getClass().getSimpleName();
+    }
+}

--- a/services/catalog-service/src/test/java/com/vellumhub/catalog_service/module/book/domain/handler/CreateBookHandlerTest.java
+++ b/services/catalog-service/src/test/java/com/vellumhub/catalog_service/module/book/domain/handler/CreateBookHandlerTest.java
@@ -9,12 +9,14 @@ import com.vellumhub.catalog_service.module.book.domain.port.BookEventProducer;
 import com.vellumhub.catalog_service.module.book.domain.port.BookRepository;
 import com.vellumhub.catalog_service.module.book.domain.port.GenreRepository;
 import com.vellumhub.catalog_service.module.book_request.domain.exception.BookRequestDomainException;
+import com.vellumhub.catalog_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -44,8 +46,20 @@ class CreateBookHandlerTest {
     @Mock
     private BookEventProducer<String, CreateBookEvent> bookEventProducer;
 
-    @InjectMocks
     private CreateBookHandler createBookHandler;
+
+    private SimpleMeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        createBookHandler = new CreateBookHandler(
+                bookRepository,
+                genreRepository,
+                bookEventProducer,
+                new VellumHubMetrics(meterRegistry)
+        );
+    }
 
     @Nested
     @DisplayName("Success Scenarios")
@@ -100,6 +114,7 @@ class CreateBookHandlerTest {
             assertThat(capturedEvent.title()).isEqualTo("The Hobbit");
             assertThat(capturedEvent.author()).isEqualTo("J.R.R. Tolkien");
             assertThat(capturedEvent.genres()).containsExactlyInAnyOrder("Fantasy", "Adventure");
+            assertThat(booksCreatedCount()).isEqualTo(1.0);
         }
     }
 
@@ -159,5 +174,13 @@ class CreateBookHandlerTest {
             then(bookRepository).should(never()).save(any());
             then(bookEventProducer).shouldHaveNoInteractions();
         }
+    }
+
+    private double booksCreatedCount() {
+        return meterRegistry.get(VellumHubMetrics.BOOKS_CREATED)
+                .tag("operation", "book_creation")
+                .tag("result", "success")
+                .counter()
+                .count();
     }
 }

--- a/services/catalog-service/src/test/java/com/vellumhub/catalog_service/module/book/domain/handler/DeleteBookHandlerTest.java
+++ b/services/catalog-service/src/test/java/com/vellumhub/catalog_service/module/book/domain/handler/DeleteBookHandlerTest.java
@@ -4,6 +4,7 @@ import com.vellumhub.catalog_service.module.book.domain.event.DeleteBookEvent;
 import com.vellumhub.catalog_service.module.book.domain.exception.BookNotExistException;
 import com.vellumhub.catalog_service.module.book.domain.port.BookRepository;
 import com.vellumhub.catalog_service.module.book.domain.port.BookEventProducer;
+import com.vellumhub.catalog_service.share.metrics.VellumHubMetrics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +26,9 @@ class DeleteBookHandlerTest {
 
     @Mock
     private BookEventProducer<String, DeleteBookEvent> bookEventProducer;
+
+    @Mock
+    private VellumHubMetrics vellumHubMetrics;
 
     @InjectMocks
     private DeleteBookHandler deleteMediaHandler;

--- a/services/catalog-service/src/test/java/com/vellumhub/catalog_service/module/book/domain/handler/UpdateBookHandlerTest.java
+++ b/services/catalog-service/src/test/java/com/vellumhub/catalog_service/module/book/domain/handler/UpdateBookHandlerTest.java
@@ -10,6 +10,7 @@ import com.vellumhub.catalog_service.module.book.domain.port.BookRepository;
 import com.vellumhub.catalog_service.module.book.domain.port.GenreRepository;
 import com.vellumhub.catalog_service.module.book.presentation.dto.UpdateBookRequest;
 import com.vellumhub.catalog_service.module.book_request.domain.exception.BookRequestDomainException;
+import com.vellumhub.catalog_service.share.metrics.VellumHubMetrics;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -43,6 +44,9 @@ class UpdateBookHandlerTest {
 
     @Mock
     private BookEventProducer<String, UpdateBookEvent> bookEventProducer;
+
+    @Mock
+    private VellumHubMetrics vellumHubMetrics;
 
     @InjectMocks
     private UpdateBookHandler updateBookHandler;

--- a/services/catalog-service/src/test/java/com/vellumhub/catalog_service/module/book/infrastructure/producer/KafkaBookEventProducerMetricsTest.java
+++ b/services/catalog-service/src/test/java/com/vellumhub/catalog_service/module/book/infrastructure/producer/KafkaBookEventProducerMetricsTest.java
@@ -1,0 +1,72 @@
+package com.vellumhub.catalog_service.module.book.infrastructure.producer;
+
+import com.vellumhub.catalog_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaBookEventProducerMetricsTest {
+
+    @Mock
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    private SimpleMeterRegistry meterRegistry;
+    private KafkaBookEventProducer<String, Object> producer;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        producer = new KafkaBookEventProducer<>(kafkaTemplate, new VellumHubMetrics(meterRegistry));
+    }
+
+    @Test
+    @DisplayName("Should count successful Kafka publications")
+    void shouldCountSuccessfulPublications() {
+        SendResult<String, Object> sendResult = mock(SendResult.class);
+        RecordMetadata metadata = mock(RecordMetadata.class);
+
+        when(sendResult.getRecordMetadata()).thenReturn(metadata);
+        when(metadata.topic()).thenReturn("created-book");
+        when(metadata.partition()).thenReturn(0);
+        when(metadata.offset()).thenReturn(1L);
+        when(kafkaTemplate.send("created-book", "book-id", "payload"))
+                .thenReturn(CompletableFuture.completedFuture(sendResult));
+
+        producer.send("created-book", "book-id", "payload");
+
+        assertThat(meterRegistry.get("vellumhub.kafka.events.published")
+                .tag("topic", "created-book")
+                .tag("event_type", "String")
+                .counter()
+                .count()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("Should count failed Kafka publications")
+    void shouldCountFailedPublications() {
+        when(kafkaTemplate.send("created-book", "book-id", "payload"))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("boom")));
+
+        producer.send("created-book", "book-id", "payload");
+
+        assertThat(meterRegistry.get("vellumhub.kafka.events.publish.failed")
+                .tag("topic", "created-book")
+                .tag("event_type", "String")
+                .counter()
+                .count()).isEqualTo(1.0);
+    }
+}

--- a/services/catalog-service/src/test/java/com/vellumhub/catalog_service/module/book_progress/application/handler/DefineBookStatusHandlerTest.java
+++ b/services/catalog-service/src/test/java/com/vellumhub/catalog_service/module/book_progress/application/handler/DefineBookStatusHandlerTest.java
@@ -84,7 +84,7 @@ class DefineBookStatusHandlerTest {
 
             handler.handle(request, userId, bookId);
 
-            verify(bookProgressEventProducer).send("create-reading-progress", userId.toString(), event);
+            verify(bookProgressEventProducer).send("created-reading-progress", userId.toString(), event);
         }
 
         @Test

--- a/services/catalog-service/src/test/java/com/vellumhub/catalog_service/module/book_progress/domain/use_case/UpdateBookProgressUseCaseTest.java
+++ b/services/catalog-service/src/test/java/com/vellumhub/catalog_service/module/book_progress/domain/use_case/UpdateBookProgressUseCaseTest.java
@@ -7,6 +7,7 @@ import com.vellumhub.catalog_service.module.book_progress.domain.exception.BookP
 import com.vellumhub.catalog_service.module.book_progress.domain.model.ReadingStatus;
 import com.vellumhub.catalog_service.module.book_progress.domain.port.BookProgressRepository;
 import com.vellumhub.catalog_service.module.book_progress.domain.model.BookProgress;
+import com.vellumhub.catalog_service.share.metrics.VellumHubMetrics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,6 +30,9 @@ class UpdateBookProgressUseCaseTest {
 
     @Mock
     private BookProgressRepository bookProgressRepository;
+
+    @Mock
+    private VellumHubMetrics vellumHubMetrics;
 
     @InjectMocks
     private UpdateBookProgressUseCase useCase;

--- a/services/engagement-service/pom.xml
+++ b/services/engagement-service/pom.xml
@@ -142,6 +142,21 @@
                     <target>21</target>
                     <compilerArgs>--enable-preview</compilerArgs>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
+                                <compileSourceRoot>${project.basedir}/src/test/java</compileSourceRoot>
+                            </compileSourceRoots>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/book_snapshot/application/use_case/CreateBookSnapshotUseCase.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/book_snapshot/application/use_case/CreateBookSnapshotUseCase.java
@@ -15,7 +15,8 @@ public class CreateBookSnapshotUseCase {
     }
 
     public void execute(CreateBookSnapshotCommand command) {
-        var bookSnapshot = new BookSnapshot(command.bookId());
+        var bookSnapshot = bookSnapshotRepository.findById(command.bookId())
+                .orElseGet(() -> new BookSnapshot(command.bookId()));
 
         bookSnapshotRepository.save(bookSnapshot);
     }

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/book_snapshot/presentation/consumer/CreateBookEventConsumer.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/book_snapshot/presentation/consumer/CreateBookEventConsumer.java
@@ -3,6 +3,8 @@ package com.vellumhub.engagement_service.module.book_snapshot.presentation.consu
 import com.vellumhub.engagement_service.module.book_snapshot.application.command.CreateBookSnapshotCommand;
 import com.vellumhub.engagement_service.module.book_snapshot.application.use_case.CreateBookSnapshotUseCase;
 import com.vellumhub.engagement_service.module.book_snapshot.presentation.event.CreateBookEvent;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -11,10 +13,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class CreateBookEventConsumer {
 
-    private final CreateBookSnapshotUseCase createBookSnapshotUseCase;
+    private static final String TOPIC = "created-book";
+    private static final String EVENT_TYPE = "CreateBookEvent";
+    private static final String CONSUMER_GROUP = "engagement-service";
 
-    public CreateBookEventConsumer(CreateBookSnapshotUseCase createBookSnapshotUseCase) {
+    private final CreateBookSnapshotUseCase createBookSnapshotUseCase;
+    private final VellumHubMetrics metrics;
+
+    public CreateBookEventConsumer(CreateBookSnapshotUseCase createBookSnapshotUseCase, VellumHubMetrics metrics) {
         this.createBookSnapshotUseCase = createBookSnapshotUseCase;
+        this.metrics = metrics;
     }
 
     @KafkaListener(
@@ -22,10 +30,19 @@ public class CreateBookEventConsumer {
             groupId = "${kafka.group-id}"
     )
     public void consume(CreateBookEvent event) {
+        Timer.Sample sample = metrics.startKafkaProcessing();
         log.info("CreateBookEvent received for bookId: {}", event.bookId());
 
-        var command = new CreateBookSnapshotCommand(event.bookId());
-        createBookSnapshotUseCase.execute(command);
+        try {
+            var command = new CreateBookSnapshotCommand(event.bookId());
+            createBookSnapshotUseCase.execute(command);
+            metrics.recordKafkaConsumed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "success");
+        } catch (RuntimeException ex) {
+            metrics.recordKafkaConsumeFailed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "failure");
+            throw ex;
+        }
 
         log.info("Book snapshot successfully created for bookId: {}", event.bookId());
 

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/book_snapshot/presentation/consumer/DeleteBookEventConsumer.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/book_snapshot/presentation/consumer/DeleteBookEventConsumer.java
@@ -3,6 +3,8 @@ package com.vellumhub.engagement_service.module.book_snapshot.presentation.consu
 import com.vellumhub.engagement_service.module.book_snapshot.application.command.DeleteBookSnapshotCommand;
 import com.vellumhub.engagement_service.module.book_snapshot.application.use_case.DeleteBookSnapshotUseCase;
 import com.vellumhub.engagement_service.module.book_snapshot.presentation.event.DeleteBookEvent;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -11,10 +13,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class DeleteBookEventConsumer {
 
-    private final DeleteBookSnapshotUseCase deleteBookSnapshotUseCase;
+    private static final String TOPIC = "deleted-book";
+    private static final String EVENT_TYPE = "DeleteBookEvent";
+    private static final String CONSUMER_GROUP = "engagement-service";
 
-    public DeleteBookEventConsumer(DeleteBookSnapshotUseCase deleteBookSnapshotUseCase) {
+    private final DeleteBookSnapshotUseCase deleteBookSnapshotUseCase;
+    private final VellumHubMetrics metrics;
+
+    public DeleteBookEventConsumer(DeleteBookSnapshotUseCase deleteBookSnapshotUseCase, VellumHubMetrics metrics) {
         this.deleteBookSnapshotUseCase = deleteBookSnapshotUseCase;
+        this.metrics = metrics;
     }
 
     @KafkaListener(
@@ -22,10 +30,19 @@ public class DeleteBookEventConsumer {
             groupId = "${kafka.group-id}"
     )
     public void consume(DeleteBookEvent event) {
+        Timer.Sample sample = metrics.startKafkaProcessing();
         log.info("DeleteBookEvent received for bookId: {}", event.bookId());
 
-        var command = new DeleteBookSnapshotCommand(event.bookId());
-        deleteBookSnapshotUseCase.execute(command);
+        try {
+            var command = new DeleteBookSnapshotCommand(event.bookId());
+            deleteBookSnapshotUseCase.execute(command);
+            metrics.recordKafkaConsumed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "success");
+        } catch (RuntimeException ex) {
+            metrics.recordKafkaConsumeFailed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "failure");
+            throw ex;
+        }
 
         log.info("Book snapshot successfully deleted for bookId: {}", event.bookId());
 

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/rating/domain/use_case/CreateRatingUseCase.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/rating/domain/use_case/CreateRatingUseCase.java
@@ -6,6 +6,7 @@ import com.vellumhub.engagement_service.module.rating.domain.exception.RatingAlr
 import com.vellumhub.engagement_service.module.rating.domain.exception.RatingDomainException;
 import com.vellumhub.engagement_service.module.rating.domain.model.Rating;
 import com.vellumhub.engagement_service.module.rating.domain.port.RatingRepository;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -15,10 +16,12 @@ public class CreateRatingUseCase {
 
     private final RatingRepository ratingRepository;
     private final BookSnapshotRepository bookSnapshotRepository;
+    private final VellumHubMetrics metrics;
 
-    public CreateRatingUseCase(RatingRepository ratingRepository, BookSnapshotRepository bookSnapshotRepository) {
+    public CreateRatingUseCase(RatingRepository ratingRepository, BookSnapshotRepository bookSnapshotRepository, VellumHubMetrics metrics) {
         this.ratingRepository = ratingRepository;
         this.bookSnapshotRepository = bookSnapshotRepository;
+        this.metrics = metrics;
     }
 
     public Rating execute(CreateRatingCommand command) {
@@ -36,7 +39,9 @@ public class CreateRatingUseCase {
                 .timestamp(LocalDateTime.now())
                 .build();
 
-        return ratingRepository.save(rating);
+        Rating savedRating = ratingRepository.save(rating);
+        metrics.recordBusinessCounter(VellumHubMetrics.RATINGS_CREATED, "rating_creation", "success");
+        return savedRating;
     }
 
 }

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/rating/infrastructure/producer/KafkaEventProducer.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/rating/infrastructure/producer/KafkaEventProducer.java
@@ -1,6 +1,7 @@
 package com.vellumhub.engagement_service.module.rating.infrastructure.producer;
 
 import com.vellumhub.engagement_service.module.rating.domain.port.EventProducer;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
@@ -13,9 +14,11 @@ import java.util.concurrent.CompletableFuture;
 public class KafkaEventProducer<K, V> implements EventProducer<K, V> {
 
     private final KafkaTemplate<K, V> kafkaTemplate;
+    private final VellumHubMetrics metrics;
 
-    public KafkaEventProducer(KafkaTemplate<K, V> kafkaTemplate) {
+    public KafkaEventProducer(KafkaTemplate<K, V> kafkaTemplate, VellumHubMetrics metrics) {
         this.kafkaTemplate = kafkaTemplate;
+        this.metrics = metrics;
     }
 
     @Override
@@ -26,8 +29,10 @@ public class KafkaEventProducer<K, V> implements EventProducer<K, V> {
 
         future.whenComplete((result, ex) -> {
             if (ex == null) {
+                metrics.recordKafkaPublished(topic, value);
                 handleSuccess(topic, key, result);
             } else {
+                metrics.recordKafkaPublishFailed(topic, value);
                 handleFailure(topic, key, ex);
             }
         });

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/reaction/application/use_case/CreateReactionUseCase.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/reaction/application/use_case/CreateReactionUseCase.java
@@ -7,6 +7,7 @@ import com.vellumhub.engagement_service.module.reaction.domain.event.ReactionCha
 import com.vellumhub.engagement_service.module.reaction.domain.model.Reaction;
 import com.vellumhub.engagement_service.module.reaction.domain.port.EventProducer;
 import com.vellumhub.engagement_service.module.reaction.domain.port.ReactionRepository;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,11 +17,13 @@ public class CreateReactionUseCase {
     private final ReactionRepository reactionRepository;
     private final BookSnapshotRepository bookSnapshotRepository;
     private final EventProducer<String, ReactionChangedEvent> eventProducer;
+    private final VellumHubMetrics metrics;
 
-    public CreateReactionUseCase(ReactionRepository reactionRepository, BookSnapshotRepository bookSnapshotRepository, EventProducer<String, ReactionChangedEvent> eventProducer) {
+    public CreateReactionUseCase(ReactionRepository reactionRepository, BookSnapshotRepository bookSnapshotRepository, EventProducer<String, ReactionChangedEvent> eventProducer, VellumHubMetrics metrics) {
         this.reactionRepository = reactionRepository;
         this.bookSnapshotRepository = bookSnapshotRepository;
         this.eventProducer = eventProducer;
+        this.metrics = metrics;
     }
 
     @Transactional
@@ -39,6 +42,7 @@ public class CreateReactionUseCase {
         var event = ReactionChangedEvent.from(reaction);
 
         eventProducer.send("user-reaction-changed", event.userId().toString(), event);
+        metrics.recordBusinessCounter(VellumHubMetrics.REACTIONS_CHANGED, "reaction_creation", "success");
     }
 
 }

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/reaction/application/use_case/UpdateReactionUseCase.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/reaction/application/use_case/UpdateReactionUseCase.java
@@ -5,6 +5,7 @@ import com.vellumhub.engagement_service.module.reaction.domain.event.ReactionCha
 import com.vellumhub.engagement_service.module.reaction.domain.model.Reaction;
 import com.vellumhub.engagement_service.module.reaction.domain.port.EventProducer;
 import com.vellumhub.engagement_service.module.reaction.domain.port.ReactionRepository;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,10 +14,12 @@ public class UpdateReactionUseCase {
 
     private final ReactionRepository reactionRepository;
     private final EventProducer<String, ReactionChangedEvent> eventProducer;
+    private final VellumHubMetrics metrics;
 
-    public UpdateReactionUseCase(ReactionRepository reactionRepository, EventProducer<String, ReactionChangedEvent> eventProducer) {
+    public UpdateReactionUseCase(ReactionRepository reactionRepository, EventProducer<String, ReactionChangedEvent> eventProducer, VellumHubMetrics metrics) {
         this.reactionRepository = reactionRepository;
         this.eventProducer = eventProducer;
+        this.metrics = metrics;
     }
 
     @Transactional
@@ -31,6 +34,7 @@ public class UpdateReactionUseCase {
         var event = ReactionChangedEvent.from(reaction);
 
         eventProducer.send("user-reaction-changed", event.userId().toString(), event);
+        metrics.recordBusinessCounter(VellumHubMetrics.REACTIONS_CHANGED, "reaction_update", "success");
     }
 
 }

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/reaction/infrastructure/kafka/producer/KafkaEventProducerAdapter.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/reaction/infrastructure/kafka/producer/KafkaEventProducerAdapter.java
@@ -1,6 +1,7 @@
 package com.vellumhub.engagement_service.module.reaction.infrastructure.kafka.producer;
 
 import com.vellumhub.engagement_service.module.reaction.domain.port.EventProducer;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -14,9 +15,11 @@ import java.util.concurrent.CompletableFuture;
 public class KafkaEventProducerAdapter<K,E> implements EventProducer<K, E> {
 
     private final KafkaTemplate<K, E> kafkaTemplate;
+    private final VellumHubMetrics metrics;
 
-    public KafkaEventProducerAdapter(KafkaTemplate<K, E> kafkaTemplate) {
+    public KafkaEventProducerAdapter(KafkaTemplate<K, E> kafkaTemplate, VellumHubMetrics metrics) {
         this.kafkaTemplate = kafkaTemplate;
+        this.metrics = metrics;
     }
 
     @Override
@@ -27,6 +30,7 @@ public class KafkaEventProducerAdapter<K,E> implements EventProducer<K, E> {
 
         future.whenComplete((result, ex) -> {
             if (ex != null) {
+                metrics.recordKafkaPublishFailed(topic, event);
                 log.error(
                         "Failed to send event to Kafka — topic: {}, key: {}, reason: {}",
                         topic, key, ex.getMessage(), ex
@@ -34,6 +38,7 @@ public class KafkaEventProducerAdapter<K,E> implements EventProducer<K, E> {
                 handleSendFailure(topic, key, event, ex);
             } else {
                 RecordMetadata metadata = result.getRecordMetadata();
+                metrics.recordKafkaPublished(topic, event);
                 log.info(
                         "Event successfully sent to Kafka — topic: {}, partition: {}, offset: {}, key: {}",
                         metadata.topic(), metadata.partition(), metadata.offset(), key

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/reading_session_entry/infrastructure/kafka/consumer/CreateReadingProgressEventConsumer.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/reading_session_entry/infrastructure/kafka/consumer/CreateReadingProgressEventConsumer.java
@@ -3,6 +3,8 @@ package com.vellumhub.engagement_service.module.reading_session_entry.infrastruc
 import com.vellumhub.engagement_service.module.reading_session_entry.application.command.CreateReadingSessionEntryCommand;
 import com.vellumhub.engagement_service.module.reading_session_entry.application.use_case.CreateReadingSessionEntryUseCase;
 import com.vellumhub.engagement_service.module.reading_session_entry.infrastructure.kafka.event.CreateBookProgressEvent;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -11,10 +13,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class CreateReadingProgressEventConsumer {
 
-    private final CreateReadingSessionEntryUseCase createReadingSessionEntryUseCase;
+    private static final String TOPIC = "created-reading-progress";
+    private static final String EVENT_TYPE = "CreateBookProgressEvent";
+    private static final String CONSUMER_GROUP = "engagement-service";
 
-    public CreateReadingProgressEventConsumer(CreateReadingSessionEntryUseCase createReadingSessionEntryUseCase) {
+    private final CreateReadingSessionEntryUseCase createReadingSessionEntryUseCase;
+    private final VellumHubMetrics metrics;
+
+    public CreateReadingProgressEventConsumer(CreateReadingSessionEntryUseCase createReadingSessionEntryUseCase, VellumHubMetrics metrics) {
         this.createReadingSessionEntryUseCase = createReadingSessionEntryUseCase;
+        this.metrics = metrics;
     }
 
     @KafkaListener(
@@ -22,6 +30,7 @@ public class CreateReadingProgressEventConsumer {
             groupId = "engagement-service"
     )
     public void consume(CreateBookProgressEvent event){
+        Timer.Sample sample = metrics.startKafkaProcessing();
         log.info(
                 "Received CreateBookProgressEvent. operation=kafka_consume, topic=created-reading-progress, event_type=CreateBookProgressEvent, userId={}, bookId={}, progress={}, page={}",
                 event.userId(),
@@ -44,7 +53,15 @@ public class CreateReadingProgressEventConsumer {
                 event.initPage()
         );
 
-        createReadingSessionEntryUseCase.execute(command);
+        try {
+            createReadingSessionEntryUseCase.execute(command);
+            metrics.recordKafkaConsumed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "success");
+        } catch (RuntimeException ex) {
+            metrics.recordKafkaConsumeFailed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "failure");
+            throw ex;
+        }
 
         log.info("Finished processing CreateBookProgressEvent for userId: {}, bookId: {}", event.userId(), event.bookId());
     }

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/reading_session_entry/infrastructure/kafka/consumer/UpdateReadingProgressEventConsumer.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/reading_session_entry/infrastructure/kafka/consumer/UpdateReadingProgressEventConsumer.java
@@ -3,6 +3,8 @@ package com.vellumhub.engagement_service.module.reading_session_entry.infrastruc
 import com.vellumhub.engagement_service.module.reading_session_entry.application.command.CreateReadingSessionEntryCommand;
 import com.vellumhub.engagement_service.module.reading_session_entry.application.use_case.CreateReadingSessionEntryUseCase;
 import com.vellumhub.engagement_service.module.reading_session_entry.infrastructure.kafka.event.UpdateBookProgressEvent;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -11,10 +13,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class UpdateReadingProgressEventConsumer {
 
-    private final CreateReadingSessionEntryUseCase createReadingSessionEntryUseCase;
+    private static final String TOPIC = "updated-reading-progress";
+    private static final String EVENT_TYPE = "UpdateBookProgressEvent";
+    private static final String CONSUMER_GROUP = "engagement-service";
 
-    public UpdateReadingProgressEventConsumer(CreateReadingSessionEntryUseCase createReadingSessionEntryUseCase) {
+    private final CreateReadingSessionEntryUseCase createReadingSessionEntryUseCase;
+    private final VellumHubMetrics metrics;
+
+    public UpdateReadingProgressEventConsumer(CreateReadingSessionEntryUseCase createReadingSessionEntryUseCase, VellumHubMetrics metrics) {
         this.createReadingSessionEntryUseCase = createReadingSessionEntryUseCase;
+        this.metrics = metrics;
     }
 
     @KafkaListener(
@@ -22,6 +30,7 @@ public class UpdateReadingProgressEventConsumer {
             groupId = "engagement-service"
     )
     public void consume(UpdateBookProgressEvent event){
+        Timer.Sample sample = metrics.startKafkaProcessing();
         log.info(
                 "Received UpdateBookProgressEvent. operation=kafka_consume, topic=updated-reading-progress, event_type=UpdateBookProgressEvent, userId={}, bookId={}, progress={}, page={}",
                 event.userId(),
@@ -44,7 +53,15 @@ public class UpdateReadingProgressEventConsumer {
                 event.newPage()
         );
 
-        createReadingSessionEntryUseCase.execute(command);
+        try {
+            createReadingSessionEntryUseCase.execute(command);
+            metrics.recordKafkaConsumed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "success");
+        } catch (RuntimeException ex) {
+            metrics.recordKafkaConsumeFailed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "failure");
+            throw ex;
+        }
 
         log.info("Finished processing UpdateBookProgressEvent for userId: {}, bookId: {}", event.userId(), event.bookId());
     }

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/reading_session_entry/infrastructure/kafka/publisher/KafkaReadingSessionEventPublisher.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/module/reading_session_entry/infrastructure/kafka/publisher/KafkaReadingSessionEventPublisher.java
@@ -1,6 +1,7 @@
 package com.vellumhub.engagement_service.module.reading_session_entry.infrastructure.kafka.publisher;
 
 import com.vellumhub.engagement_service.module.reading_session_entry.domain.port.ReadingSessionEventPublisher;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -14,9 +15,11 @@ import java.util.concurrent.CompletableFuture;
 public class KafkaReadingSessionEventPublisher<K, E> implements ReadingSessionEventPublisher<K, E> {
 
     private final KafkaTemplate<K, E> kafkaTemplate;
+    private final VellumHubMetrics metrics;
 
-    public KafkaReadingSessionEventPublisher(KafkaTemplate<K, E> kafkaTemplate) {
+    public KafkaReadingSessionEventPublisher(KafkaTemplate<K, E> kafkaTemplate, VellumHubMetrics metrics) {
         this.kafkaTemplate = kafkaTemplate;
+        this.metrics = metrics;
     }
 
     @Override
@@ -27,6 +30,7 @@ public class KafkaReadingSessionEventPublisher<K, E> implements ReadingSessionEv
 
         future.whenComplete((result, ex) -> {
             if (ex != null) {
+                metrics.recordKafkaPublishFailed(topic, event);
                 log.error(
                         "Failed to send event to Kafka — topic: {}, key: {}, reason: {}",
                         topic, key, ex.getMessage(), ex
@@ -34,6 +38,7 @@ public class KafkaReadingSessionEventPublisher<K, E> implements ReadingSessionEv
                 handleSendFailure(topic, key, event, ex);
             } else {
                 RecordMetadata metadata = result.getRecordMetadata();
+                metrics.recordKafkaPublished(topic, event);
                 log.info(
                         "Event successfully sent to Kafka — topic: {}, partition: {}, offset: {}, key: {}",
                         metadata.topic(), metadata.partition(), metadata.offset(), key

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/share/config/DltKafkaConsumerConfig.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/share/config/DltKafkaConsumerConfig.java
@@ -1,0 +1,35 @@
+package com.vellumhub.engagement_service.share.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class DltKafkaConsumerConfig {
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, byte[]> dltKafkaListenerContainerFactory(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers
+    ) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+
+        ConsumerFactory<String, byte[]> consumerFactory = new DefaultKafkaConsumerFactory<>(properties);
+        ConcurrentKafkaListenerContainerFactory<String, byte[]> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        return factory;
+    }
+}

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfig.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfig.java
@@ -11,7 +11,6 @@ import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
 import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
 import org.springframework.kafka.support.KafkaHeaders;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Configuration
@@ -44,26 +43,27 @@ public class KafkaRetryConfig {
                 .create(template);
     }
 
-
     /**
      * Listens to all Dead Letter Topics across the microservice.
      * The topicPattern ".*-dlt" ensures any topic ending with "-dlt" is captured here.
      */
     @KafkaListener(
             topicPattern = ".*-dlt",
-            groupId = "engagement-service-dlt-group"
+            groupId = "engagement-service-dlt-group",
+            containerFactory = "dltKafkaListenerContainerFactory"
     )
     public void consumeDlt(
-            String payload,
+            byte[] payload,
             @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
-            @Header(KafkaHeaders.ORIGINAL_TOPIC) String originalTopic,
-            @Header(KafkaHeaders.EXCEPTION_MESSAGE) String errorMessage
+            @Header(name = KafkaHeaders.ORIGINAL_TOPIC, required = false) String originalTopic,
+            @Header(name = KafkaHeaders.EXCEPTION_MESSAGE, required = false) String errorMessage
     ) {
 
-        metrics.recordKafkaDlt(originalTopic, DLT_CONSUMER_GROUP);
+        String quarantinedTopic = originalTopic(topic, originalTopic);
+        metrics.recordKafkaDlt(quarantinedTopic, DLT_CONSUMER_GROUP);
         log.error(
                 "Kafka DLT message quarantined. operation=kafka_dlt_quarantine, event_type=kafka_dlt, originalTopic={}, dltTopic={}, error={}, payloadBytes={}",
-                originalTopic,
+                quarantinedTopic,
                 topic,
                 errorMessage,
                 payloadByteLength(payload)
@@ -71,8 +71,18 @@ public class KafkaRetryConfig {
 
     }
 
-    private int payloadByteLength(String payload) {
-        return payload == null ? 0 : payload.getBytes(StandardCharsets.UTF_8).length;
+    private String originalTopic(String dltTopic, String originalTopic) {
+        if (originalTopic != null && !originalTopic.isBlank()) {
+            return originalTopic;
+        }
+        if (dltTopic != null && dltTopic.endsWith("-dlt")) {
+            return dltTopic.substring(0, dltTopic.length() - "-dlt".length());
+        }
+        return "unknown";
+    }
+
+    private int payloadByteLength(byte[] payload) {
+        return payload == null ? 0 : payload.length;
     }
 
 }

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfig.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfig.java
@@ -1,17 +1,27 @@
 package com.vellumhub.engagement_service.share.config;
 
 import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.handler.annotation.Header;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
 import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
 import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.serializer.DelegatingByTypeSerializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Configuration
 @Slf4j
@@ -27,11 +37,12 @@ public class KafkaRetryConfig {
 
     /**
      * Defines a default retry configuration for Kafka listeners in the application.
-     * @param template the KafkaTemplate used to send messages to retry topics
      * @return a RetryTopicConfiguration that applies to all specified topics with a fixed backoff strategy and a maximum of 3 attempts.
      */
     @Bean
-    public RetryTopicConfiguration defaultRetryConfig(KafkaTemplate<String, Object> template) {
+    public RetryTopicConfiguration defaultRetryConfig(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers
+    ) {
         return RetryTopicConfigurationBuilder
                 .newInstance()
                 .maxAttempts(3)
@@ -40,7 +51,7 @@ public class KafkaRetryConfig {
                         "created-book",
                         "deleted-book"
                 ))
-                .create(template);
+                .create(retryTopicKafkaTemplate(bootstrapServers));
     }
 
     /**
@@ -83,6 +94,22 @@ public class KafkaRetryConfig {
 
     private int payloadByteLength(byte[] payload) {
         return payload == null ? 0 : payload.length;
+    }
+
+    private KafkaTemplate<String, Object> retryTopicKafkaTemplate(String bootstrapServers) {
+        Map<String, Object> properties = Map.of(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        Map<Class<?>, org.apache.kafka.common.serialization.Serializer<?>> delegates = new LinkedHashMap<>();
+        delegates.put(byte[].class, new ByteArraySerializer());
+        delegates.put(String.class, new StringSerializer());
+        delegates.put(Object.class, new JsonSerializer<>());
+
+        ProducerFactory<String, Object> producerFactory = new DefaultKafkaProducerFactory<>(
+                properties,
+                new StringSerializer(),
+                new DelegatingByTypeSerializer(delegates, true)
+        );
+        return new KafkaTemplate<>(producerFactory);
     }
 
 }

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfig.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfig.java
@@ -1,5 +1,6 @@
 package com.vellumhub.engagement_service.share.config;
 
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
 import org.springframework.messaging.handler.annotation.Header;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -16,6 +17,14 @@ import java.util.List;
 @Configuration
 @Slf4j
 public class KafkaRetryConfig {
+
+    private static final String DLT_CONSUMER_GROUP = "engagement-service-dlt-group";
+
+    private final VellumHubMetrics metrics;
+
+    public KafkaRetryConfig(VellumHubMetrics metrics) {
+        this.metrics = metrics;
+    }
 
     /**
      * Defines a default retry configuration for Kafka listeners in the application.
@@ -51,6 +60,7 @@ public class KafkaRetryConfig {
             @Header(KafkaHeaders.EXCEPTION_MESSAGE) String errorMessage
     ) {
 
+        metrics.recordKafkaDlt(originalTopic, DLT_CONSUMER_GROUP);
         log.error(
                 "Kafka DLT message quarantined. operation=kafka_dlt_quarantine, event_type=kafka_dlt, originalTopic={}, dltTopic={}, error={}, payloadBytes={}",
                 originalTopic,

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfig.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfig.java
@@ -47,6 +47,8 @@ public class KafkaRetryConfig {
                 .newInstance()
                 .maxAttempts(3)
                 .fixedBackOff(3000)
+                .doNotRetryOnDltFailure()
+                .autoStartDltHandler(false)
                 .includeTopics(List.of(
                         "created-book",
                         "deleted-book"

--- a/services/engagement-service/src/main/java/com/vellumhub/engagement_service/share/metrics/VellumHubMetrics.java
+++ b/services/engagement-service/src/main/java/com/vellumhub/engagement_service/share/metrics/VellumHubMetrics.java
@@ -1,0 +1,89 @@
+package com.vellumhub.engagement_service.share.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class VellumHubMetrics {
+
+    public static final String KAFKA_EVENTS_PUBLISHED = "vellumhub.kafka.events.published";
+    public static final String KAFKA_EVENTS_PUBLISH_FAILED = "vellumhub.kafka.events.publish.failed";
+    public static final String KAFKA_EVENTS_CONSUMED = "vellumhub.kafka.events.consumed";
+    public static final String KAFKA_EVENTS_CONSUME_FAILED = "vellumhub.kafka.events.consume.failed";
+    public static final String KAFKA_EVENT_PROCESSING_DURATION = "vellumhub.kafka.event.processing.duration";
+    public static final String KAFKA_DLT_EVENTS = "vellumhub.kafka.dlt.events";
+
+    public static final String USERS_CREATED = "vellumhub.users.created";
+    public static final String BOOKS_CREATED = "vellumhub.books.created";
+    public static final String BOOKS_UPDATED = "vellumhub.books.updated";
+    public static final String BOOKS_DELETED = "vellumhub.books.deleted";
+    public static final String READING_PROGRESS_UPDATED = "vellumhub.reading.progress.updated";
+    public static final String RATINGS_CREATED = "vellumhub.ratings.created";
+    public static final String REACTIONS_CHANGED = "vellumhub.reactions.changed";
+    public static final String RECOMMENDATIONS_REQUESTED = "vellumhub.recommendations.requested";
+    public static final String RECOMMENDATIONS_GENERATED = "vellumhub.recommendations.generated";
+    public static final String RECOMMENDATION_EMPTY_RESULTS = "vellumhub.recommendation.empty.results";
+    public static final String RECOMMENDATION_GENERATION_DURATION = "vellumhub.recommendation.generation.duration";
+
+    private final MeterRegistry meterRegistry;
+
+    public VellumHubMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = Objects.requireNonNull(meterRegistry, "meterRegistry must not be null");
+    }
+
+    public void recordKafkaPublished(String topic, Object event) {
+        counter(KAFKA_EVENTS_PUBLISHED, "topic", topic, "event_type", eventType(event), "result", "success").increment();
+    }
+
+    public void recordKafkaPublishFailed(String topic, Object event) {
+        counter(KAFKA_EVENTS_PUBLISH_FAILED, "topic", topic, "event_type", eventType(event), "result", "failure").increment();
+    }
+
+    public Timer.Sample startKafkaProcessing() {
+        return Timer.start(meterRegistry);
+    }
+
+    public void recordKafkaConsumed(String topic, String eventType, String consumerGroup) {
+        counter(KAFKA_EVENTS_CONSUMED, "topic", topic, "event_type", eventType, "consumer_group", consumerGroup, "result", "success").increment();
+    }
+
+    public void recordKafkaConsumeFailed(String topic, String eventType, String consumerGroup) {
+        counter(KAFKA_EVENTS_CONSUME_FAILED, "topic", topic, "event_type", eventType, "consumer_group", consumerGroup, "result", "failure").increment();
+    }
+
+    public void recordKafkaProcessingDuration(Timer.Sample sample, String topic, String eventType, String consumerGroup, String result) {
+        sample.stop(Timer.builder(KAFKA_EVENT_PROCESSING_DURATION)
+                .tags("topic", topic, "event_type", eventType, "consumer_group", consumerGroup, "result", result)
+                .register(meterRegistry));
+    }
+
+    public void recordKafkaDlt(String originalTopic, String consumerGroup) {
+        counter(KAFKA_DLT_EVENTS, "topic", originalTopic, "event_type", "kafka_dlt", "consumer_group", consumerGroup, "operation", "kafka_dlt_quarantine", "result", "quarantined").increment();
+    }
+
+    public void recordBusinessCounter(String name, String operation, String result) {
+        counter(name, "operation", operation, "result", result).increment();
+    }
+
+    public Timer.Sample startBusinessTimer() {
+        return Timer.start(meterRegistry);
+    }
+
+    public void recordRecommendationGenerationDuration(Timer.Sample sample, String result) {
+        sample.stop(Timer.builder(RECOMMENDATION_GENERATION_DURATION)
+                .tags("operation", "recommendation_generation", "result", result)
+                .register(meterRegistry));
+    }
+
+    private Counter counter(String name, String... tags) {
+        return Counter.builder(name).tags(tags).register(meterRegistry);
+    }
+
+    private String eventType(Object event) {
+        return event == null ? "unknown" : event.getClass().getSimpleName();
+    }
+}

--- a/services/engagement-service/src/test/java/com/vellumhub/engagement_service/module/rating/domain/use_case/CreateRatingUseCaseTest.java
+++ b/services/engagement-service/src/test/java/com/vellumhub/engagement_service/module/rating/domain/use_case/CreateRatingUseCaseTest.java
@@ -1,14 +1,17 @@
 package com.vellumhub.engagement_service.module.rating.domain.use_case;
 
+import com.vellumhub.engagement_service.module.book_snapshot.domain.port.BookSnapshotRepository;
 import com.vellumhub.engagement_service.module.rating.domain.command.CreateRatingCommand;
 import com.vellumhub.engagement_service.module.rating.domain.exception.RatingAlreadyExistException;
 import com.vellumhub.engagement_service.module.rating.domain.model.Rating;
 import com.vellumhub.engagement_service.module.rating.domain.port.RatingRepository;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -25,8 +28,22 @@ class CreateRatingUseCaseTest {
     @Mock
     private RatingRepository ratingRepository;
 
-    @InjectMocks
+    @Mock
+    private BookSnapshotRepository bookSnapshotRepository;
+
     private CreateRatingUseCase createRatingUseCase;
+
+    private SimpleMeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        createRatingUseCase = new CreateRatingUseCase(
+                ratingRepository,
+                bookSnapshotRepository,
+                new VellumHubMetrics(meterRegistry)
+        );
+    }
 
     @Test
     @DisplayName("Should create rating successfully when it does not already exist")
@@ -36,6 +53,7 @@ class CreateRatingUseCaseTest {
         UUID bookId = UUID.randomUUID();
         CreateRatingCommand command = new CreateRatingCommand(userId, bookId, 4, "Great book!");
 
+        when(bookSnapshotRepository.existsById(bookId)).thenReturn(true);
         when(ratingRepository.existsByUserIdAndBookId(userId, bookId)).thenReturn(false);
         when(ratingRepository.save(any(Rating.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -52,6 +70,7 @@ class CreateRatingUseCaseTest {
         ArgumentCaptor<Rating> captor = ArgumentCaptor.forClass(Rating.class);
         verify(ratingRepository, times(1)).save(captor.capture());
         assertThat(captor.getValue().getTimestamp()).isNotNull();
+        assertThat(ratingsCreatedCount()).isEqualTo(1.0);
     }
 
     @Test
@@ -62,6 +81,7 @@ class CreateRatingUseCaseTest {
         UUID bookId = UUID.randomUUID();
         CreateRatingCommand command = new CreateRatingCommand(userId, bookId, 3, "OK");
 
+        when(bookSnapshotRepository.existsById(bookId)).thenReturn(true);
         when(ratingRepository.existsByUserIdAndBookId(userId, bookId)).thenReturn(true);
 
         // Act & Assert
@@ -69,5 +89,13 @@ class CreateRatingUseCaseTest {
                 .isInstanceOf(RatingAlreadyExistException.class);
 
         verify(ratingRepository, never()).save(any());
+    }
+
+    private double ratingsCreatedCount() {
+        return meterRegistry.get(VellumHubMetrics.RATINGS_CREATED)
+                .tag("operation", "rating_creation")
+                .tag("result", "success")
+                .counter()
+                .count();
     }
 }

--- a/services/engagement-service/src/test/java/com/vellumhub/engagement_service/module/reaction/application/use_case/CreateReactionUseCaseMetricsTest.java
+++ b/services/engagement-service/src/test/java/com/vellumhub/engagement_service/module/reaction/application/use_case/CreateReactionUseCaseMetricsTest.java
@@ -1,0 +1,79 @@
+package com.vellumhub.engagement_service.module.reaction.application.use_case;
+
+import com.vellumhub.engagement_service.module.book_snapshot.domain.model.BookSnapshot;
+import com.vellumhub.engagement_service.module.book_snapshot.domain.port.BookSnapshotRepository;
+import com.vellumhub.engagement_service.module.reaction.application.command.CreateReactionCommand;
+import com.vellumhub.engagement_service.module.reaction.domain.event.ReactionChangedEvent;
+import com.vellumhub.engagement_service.module.reaction.domain.model.Reaction;
+import com.vellumhub.engagement_service.module.reaction.domain.model.TypeReaction;
+import com.vellumhub.engagement_service.module.reaction.domain.port.EventProducer;
+import com.vellumhub.engagement_service.module.reaction.domain.port.ReactionRepository;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CreateReactionUseCaseMetricsTest {
+
+    @Mock
+    private ReactionRepository reactionRepository;
+
+    @Mock
+    private BookSnapshotRepository bookSnapshotRepository;
+
+    @Mock
+    private EventProducer<String, ReactionChangedEvent> eventProducer;
+
+    private CreateReactionUseCase useCase;
+    private SimpleMeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        useCase = new CreateReactionUseCase(
+                reactionRepository,
+                bookSnapshotRepository,
+                eventProducer,
+                new VellumHubMetrics(meterRegistry)
+        );
+    }
+
+    @Test
+    @DisplayName("Should count created reaction after saving and publishing event")
+    void shouldCountCreatedReaction() {
+        UUID userId = UUID.randomUUID();
+        UUID bookId = UUID.randomUUID();
+        var command = new CreateReactionCommand(userId, bookId, TypeReaction.POSITIVE);
+        when(bookSnapshotRepository.findById(bookId)).thenReturn(Optional.of(new BookSnapshot(bookId)));
+
+        useCase.execute(command);
+
+        var reactionCaptor = ArgumentCaptor.forClass(Reaction.class);
+        verify(reactionRepository).save(reactionCaptor.capture());
+        verify(eventProducer).send(eq("user-reaction-changed"), eq(userId.toString()), org.mockito.ArgumentMatchers.any());
+        assertThat(reactionCaptor.getValue().getTypeReaction()).isEqualTo(TypeReaction.POSITIVE);
+        assertThat(reactionsChangedCount("reaction_creation")).isEqualTo(1.0);
+    }
+
+    private double reactionsChangedCount(String operation) {
+        return meterRegistry.get(VellumHubMetrics.REACTIONS_CHANGED)
+                .tag("operation", operation)
+                .tag("result", "success")
+                .counter()
+                .count();
+    }
+}

--- a/services/engagement-service/src/test/java/com/vellumhub/engagement_service/module/reaction/application/use_case/UpdateReactionUseCaseMetricsTest.java
+++ b/services/engagement-service/src/test/java/com/vellumhub/engagement_service/module/reaction/application/use_case/UpdateReactionUseCaseMetricsTest.java
@@ -1,0 +1,79 @@
+package com.vellumhub.engagement_service.module.reaction.application.use_case;
+
+import com.vellumhub.engagement_service.module.book_snapshot.domain.model.BookSnapshot;
+import com.vellumhub.engagement_service.module.reaction.application.command.UpdateReactionCommand;
+import com.vellumhub.engagement_service.module.reaction.domain.event.ReactionChangedEvent;
+import com.vellumhub.engagement_service.module.reaction.domain.model.Reaction;
+import com.vellumhub.engagement_service.module.reaction.domain.model.TypeReaction;
+import com.vellumhub.engagement_service.module.reaction.domain.port.EventProducer;
+import com.vellumhub.engagement_service.module.reaction.domain.port.ReactionRepository;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateReactionUseCaseMetricsTest {
+
+    @Mock
+    private ReactionRepository reactionRepository;
+
+    @Mock
+    private EventProducer<String, ReactionChangedEvent> eventProducer;
+
+    private UpdateReactionUseCase useCase;
+    private SimpleMeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        useCase = new UpdateReactionUseCase(
+                reactionRepository,
+                eventProducer,
+                new VellumHubMetrics(meterRegistry)
+        );
+    }
+
+    @Test
+    @DisplayName("Should count updated reaction after saving and publishing event")
+    void shouldCountUpdatedReaction() {
+        UUID userId = UUID.randomUUID();
+        UUID bookId = UUID.randomUUID();
+        long reactionId = 42L;
+        var reaction = Reaction.builder()
+                .id(reactionId)
+                .userId(userId)
+                .bookSnapshot(new BookSnapshot(bookId))
+                .typeReaction(TypeReaction.POSITIVE)
+                .build();
+        when(reactionRepository.findById(reactionId)).thenReturn(Optional.of(reaction));
+
+        useCase.execute(new UpdateReactionCommand(userId, reactionId, TypeReaction.VERY_POSITIVE));
+
+        verify(reactionRepository).save(reaction);
+        verify(eventProducer).send(eq("user-reaction-changed"), eq(userId.toString()), any());
+        assertThat(reaction.getTypeReaction()).isEqualTo(TypeReaction.VERY_POSITIVE);
+        assertThat(reactionsChangedCount("reaction_update")).isEqualTo(1.0);
+    }
+
+    private double reactionsChangedCount(String operation) {
+        return meterRegistry.get(VellumHubMetrics.REACTIONS_CHANGED)
+                .tag("operation", operation)
+                .tag("result", "success")
+                .counter()
+                .count();
+    }
+}

--- a/services/engagement-service/src/test/java/com/vellumhub/engagement_service/module/reading_session_entry/infrastructure/event/KafkaReadingSessionEventPublisherTest.java
+++ b/services/engagement-service/src/test/java/com/vellumhub/engagement_service/module/reading_session_entry/infrastructure/event/KafkaReadingSessionEventPublisherTest.java
@@ -1,6 +1,8 @@
 package com.vellumhub.engagement_service.module.reading_session_entry.infrastructure.event;
 
 import com.vellumhub.engagement_service.module.reading_session_entry.infrastructure.kafka.publisher.KafkaReadingSessionEventPublisher;
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,7 +28,10 @@ class KafkaReadingSessionEventPublisherTest {
     @Test
     @DisplayName("Should send event using kafka template")
     void shouldSendEventUsingKafkaTemplate() {
-        KafkaReadingSessionEventPublisher<String, Object> publisher = new KafkaReadingSessionEventPublisher<>(kafkaTemplate);
+        KafkaReadingSessionEventPublisher<String, Object> publisher = new KafkaReadingSessionEventPublisher<>(
+                kafkaTemplate,
+                new VellumHubMetrics(new SimpleMeterRegistry())
+        );
         SendResult<String, Object> sendResult = mock(SendResult.class);
         RecordMetadata recordMetadata = mock(RecordMetadata.class);
 
@@ -45,7 +50,10 @@ class KafkaReadingSessionEventPublisherTest {
     @Test
     @DisplayName("Should swallow asynchronous send failures without throwing")
     void shouldSwallowAsyncFailure() {
-        KafkaReadingSessionEventPublisher<String, Object> publisher = new KafkaReadingSessionEventPublisher<>(kafkaTemplate);
+        KafkaReadingSessionEventPublisher<String, Object> publisher = new KafkaReadingSessionEventPublisher<>(
+                kafkaTemplate,
+                new VellumHubMetrics(new SimpleMeterRegistry())
+        );
 
         when(kafkaTemplate.send("reading-session-started", "book", "payload"))
                 .thenReturn(CompletableFuture.failedFuture(new RuntimeException("boom")));

--- a/services/engagement-service/src/test/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfigTest.java
+++ b/services/engagement-service/src/test/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfigTest.java
@@ -1,5 +1,7 @@
 package com.vellumhub.engagement_service.share.config;
 
+import com.vellumhub.engagement_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.system.CapturedOutput;
@@ -12,7 +14,7 @@ class KafkaRetryConfigTest {
 
     @Test
     void dltLoggingDoesNotExposeRawPayload(CapturedOutput output) {
-        KafkaRetryConfig config = new KafkaRetryConfig();
+        KafkaRetryConfig config = new KafkaRetryConfig(new VellumHubMetrics(new SimpleMeterRegistry()));
 
         config.consumeDlt(
                 "{\"password\":\"secret\",\"token\":\"full.jwt.value\"}",
@@ -30,5 +32,19 @@ class KafkaRetryConfigTest {
                 .doesNotContain("secret")
                 .doesNotContain("full.jwt.value")
                 .doesNotContain("Message Payload");
+    }
+
+    @Test
+    void dltConsumerCountsQuarantinedEvents() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        KafkaRetryConfig config = new KafkaRetryConfig(new VellumHubMetrics(meterRegistry));
+
+        config.consumeDlt("{}", "created-book-dlt", "created-book", "boom");
+
+        assertThat(meterRegistry.get("vellumhub.kafka.dlt.events")
+                .tag("topic", "created-book")
+                .tag("consumer_group", "engagement-service-dlt-group")
+                .counter()
+                .count()).isEqualTo(1.0);
     }
 }

--- a/services/engagement-service/src/test/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfigTest.java
+++ b/services/engagement-service/src/test/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfigTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(OutputCaptureExtension.class)
@@ -17,7 +19,7 @@ class KafkaRetryConfigTest {
         KafkaRetryConfig config = new KafkaRetryConfig(new VellumHubMetrics(new SimpleMeterRegistry()));
 
         config.consumeDlt(
-                "{\"password\":\"secret\",\"token\":\"full.jwt.value\"}",
+                "{\"password\":\"secret\",\"token\":\"full.jwt.value\"}".getBytes(StandardCharsets.UTF_8),
                 "created-book-dlt",
                 "created-book",
                 "boom"
@@ -39,10 +41,24 @@ class KafkaRetryConfigTest {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         KafkaRetryConfig config = new KafkaRetryConfig(new VellumHubMetrics(meterRegistry));
 
-        config.consumeDlt("{}", "created-book-dlt", "created-book", "boom");
+        config.consumeDlt("{}".getBytes(StandardCharsets.UTF_8), "created-book-dlt", "created-book", "boom");
 
         assertThat(meterRegistry.get("vellumhub.kafka.dlt.events")
                 .tag("topic", "created-book")
+                .tag("consumer_group", "engagement-service-dlt-group")
+                .counter()
+                .count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void dltConsumerFallsBackToDltTopicWhenOriginalTopicHeaderIsMissing() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        KafkaRetryConfig config = new KafkaRetryConfig(new VellumHubMetrics(meterRegistry));
+
+        config.consumeDlt("{}".getBytes(StandardCharsets.UTF_8), "deleted-book-dlt", null, null);
+
+        assertThat(meterRegistry.get("vellumhub.kafka.dlt.events")
+                .tag("topic", "deleted-book")
                 .tag("consumer_group", "engagement-service-dlt-group")
                 .counter()
                 .count()).isEqualTo(1.0);

--- a/services/engagement-service/src/test/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfigTest.java
+++ b/services/engagement-service/src/test/java/com/vellumhub/engagement_service/share/config/KafkaRetryConfigTest.java
@@ -63,4 +63,16 @@ class KafkaRetryConfigTest {
                 .counter()
                 .count()).isEqualTo(1.0);
     }
+
+    @Test
+    void retryTopicDltHandlersAreNotAutoStarted() {
+        KafkaRetryConfig config = new KafkaRetryConfig(new VellumHubMetrics(new SimpleMeterRegistry()));
+
+        var retryConfig = config.defaultRetryConfig("localhost:9092");
+
+        assertThat(retryConfig.getDestinationTopicProperties())
+                .filteredOn(properties -> properties.isDltTopic())
+                .isNotEmpty()
+                .allSatisfy(properties -> assertThat(properties.autoStartDltHandler()).isFalse());
+    }
 }

--- a/services/engagement-service/src/test/resources/application.properties
+++ b/services/engagement-service/src/test/resources/application.properties
@@ -1,0 +1,27 @@
+# Test configuration
+spring.profiles.active=test
+
+# H2 Database configuration for tests
+spring.datasource.url=jdbc:h2:mem:engagement_db;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# JPA/Hibernate Configuration
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.flyway.enabled=false
+
+# Kafka
+kafka.group-id=engagement-service
+kafka.topics.created-book=created-book
+kafka.topics.updated-book=updated-book
+kafka.topics.deleted-book=deleted-book
+spring.kafka.bootstrap-servers=localhost:9092
+
+# CORS
+app.cors.allowed-origins=http://localhost:3000
+
+# JWT Secret for tests
+jwt.secret=bG9jYWxfc2VjcmV0X2tleV9mb3JfZW5nYWdlbWVudF90ZXN0aW5nXzEyMw==

--- a/services/recommendation-service/pom.xml
+++ b/services/recommendation-service/pom.xml
@@ -180,9 +180,24 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
+                                <compileSourceRoot>${project.basedir}/src/test/java</compileSourceRoot>
+                            </compileSourceRoots>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/recommendation/application/use_case/GetRecommendationsUseCase.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/recommendation/application/use_case/GetRecommendationsUseCase.java
@@ -4,6 +4,7 @@ import com.vellumhub.recommendation_service.module.book_feature.domain.port.Book
 import com.vellumhub.recommendation_service.module.recommendation.application.command.GetRecommendationsCommand;
 import com.vellumhub.recommendation_service.module.recommendation.domain.model.Recommendation;
 import com.vellumhub.recommendation_service.module.recommendation.domain.port.RecommendationRepository;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -14,24 +15,43 @@ public class GetRecommendationsUseCase {
 
     private final BookFeatureRepository bookFeatureRepository;
     private final RecommendationRepository recommendationRepository;
+    private final VellumHubMetrics metrics;
 
-    public GetRecommendationsUseCase(BookFeatureRepository bookFeatureRepository, RecommendationRepository recommendationRepository) {
+    public GetRecommendationsUseCase(BookFeatureRepository bookFeatureRepository, RecommendationRepository recommendationRepository, VellumHubMetrics metrics) {
         this.bookFeatureRepository = bookFeatureRepository;
         this.recommendationRepository = recommendationRepository;
+        this.metrics = metrics;
     }
 
     public List<Recommendation> execute(GetRecommendationsCommand command) {
-        List<UUID> booksId = bookFeatureRepository.findAllByUserId(
-                command.userId(),
-                command.limit(),
-                command.offset()
-        );
+        var sample = metrics.startBusinessTimer();
 
-        if(booksId == null || booksId.isEmpty()){
-            booksId = bookFeatureRepository.findMostPopularMedias(command.limit(), command.offset());
+        try {
+            List<UUID> booksId = bookFeatureRepository.findAllByUserId(
+                    command.userId(),
+                    command.limit(),
+                    command.offset()
+            );
+
+            if(booksId == null || booksId.isEmpty()){
+                booksId = bookFeatureRepository.findMostPopularMedias(command.limit(), command.offset());
+            }
+
+            List<Recommendation> recommendations = recommendationRepository.findAllById(booksId);
+
+            if (recommendations == null || recommendations.isEmpty()) {
+                metrics.recordBusinessCounter(VellumHubMetrics.RECOMMENDATION_EMPTY_RESULTS, "recommendation_generation", "empty");
+                metrics.recordRecommendationGenerationDuration(sample, "empty");
+            } else {
+                metrics.recordBusinessCounter(VellumHubMetrics.RECOMMENDATIONS_GENERATED, "recommendation_generation", "success");
+                metrics.recordRecommendationGenerationDuration(sample, "success");
+            }
+
+            return recommendations;
+        } catch (RuntimeException exception) {
+            metrics.recordRecommendationGenerationDuration(sample, "failure");
+            throw exception;
         }
-
-        return recommendationRepository.findAllById(booksId);
     }
 
 }

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/recommendation/presentation/controller/RecommendationController.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/recommendation/presentation/controller/RecommendationController.java
@@ -4,6 +4,7 @@ import com.vellumhub.recommendation_service.module.recommendation.presentation.d
 import com.vellumhub.recommendation_service.module.recommendation.presentation.mapper.RecommendationMapper;
 import com.vellumhub.recommendation_service.module.recommendation.application.use_case.GetRecommendationsUseCase;
 import com.vellumhub.recommendation_service.module.recommendation.application.command.GetRecommendationsCommand;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
 import com.vellumhub.recommendation_service.share.provider.UserAuthenticationProvider;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,11 +32,13 @@ public class RecommendationController {
     private final RecommendationMapper mapper;
 
     private final GetRecommendationsUseCase getRecommendationsUseCase;
+    private final VellumHubMetrics metrics;
 
-    public RecommendationController(UserAuthenticationProvider userAuthenticationProvider, RecommendationMapper mapper, GetRecommendationsUseCase getRecommendationsUseCase) {
+    public RecommendationController(UserAuthenticationProvider userAuthenticationProvider, RecommendationMapper mapper, GetRecommendationsUseCase getRecommendationsUseCase, VellumHubMetrics metrics) {
         this.userAuthenticationProvider = userAuthenticationProvider;
         this.mapper = mapper;
         this.getRecommendationsUseCase = getRecommendationsUseCase;
+        this.metrics = metrics;
     }
     /**
      * Returns recommendations for the authenticated user.
@@ -70,6 +73,7 @@ public class RecommendationController {
                 .map(mapper::toResponse)
                 .toList();
 
+        metrics.recordBusinessCounter(VellumHubMetrics.RECOMMENDATIONS_REQUESTED, "recommendation_request", "success");
         return ResponseEntity.ok(response);
     }
 }

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/CreateBookProgressConsumerEvent.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/CreateBookProgressConsumerEvent.java
@@ -3,6 +3,8 @@ package com.vellumhub.recommendation_service.module.user_profile.presentation.co
 import com.vellumhub.recommendation_service.module.user_profile.application.command.UpdateBookProgressCommand;
 import com.vellumhub.recommendation_service.module.user_profile.application.use_case.UpdateBookProgressUseCase;
 import com.vellumhub.recommendation_service.module.user_profile.presentation.event.UpdateBookProgressEvent;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -11,10 +13,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class CreateBookProgressConsumerEvent {
 
-    private final UpdateBookProgressUseCase updateBookProgressUseCase;
+    private static final String TOPIC = "created-reading-progress";
+    private static final String EVENT_TYPE = "UpdateBookProgressEvent";
+    private static final String CONSUMER_GROUP = "recommendation-service";
 
-    public CreateBookProgressConsumerEvent(UpdateBookProgressUseCase updateBookProgressUseCase) {
+    private final UpdateBookProgressUseCase updateBookProgressUseCase;
+    private final VellumHubMetrics metrics;
+
+    public CreateBookProgressConsumerEvent(UpdateBookProgressUseCase updateBookProgressUseCase, VellumHubMetrics metrics) {
         this.updateBookProgressUseCase = updateBookProgressUseCase;
+        this.metrics = metrics;
     }
 
     @KafkaListener(
@@ -24,6 +32,7 @@ public class CreateBookProgressConsumerEvent {
     public void consume(
             UpdateBookProgressEvent event
     ) {
+        Timer.Sample sample = metrics.startKafkaProcessing();
 
         log.info("Event received: Create book progress. UserId={}, BookId={}, Progress={}",
                 event.userId(),
@@ -39,7 +48,15 @@ public class CreateBookProgressConsumerEvent {
                 event.newPage()
         );
 
-        updateBookProgressUseCase.execute(command);
+        try {
+            updateBookProgressUseCase.execute(command);
+            metrics.recordKafkaConsumed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "success");
+        } catch (RuntimeException ex) {
+            metrics.recordKafkaConsumeFailed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "failure");
+            throw ex;
+        }
 
         log.info("Book progress update event processed successfully. UserId={}, BookId={}",
                 event.userId(),

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/CreatedRatingConsumerEvent.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/CreatedRatingConsumerEvent.java
@@ -3,6 +3,8 @@ package com.vellumhub.recommendation_service.module.user_profile.presentation.co
 import com.vellumhub.recommendation_service.module.user_profile.application.command.UpdateUserProfileWithRatingCommand;
 import com.vellumhub.recommendation_service.module.user_profile.application.use_case.UpdateUserProfileWithRatingUseCase;
 import com.vellumhub.recommendation_service.module.user_profile.presentation.event.CreatedRatingEvent;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -12,10 +14,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class CreatedRatingConsumerEvent {
 
-    private final UpdateUserProfileWithRatingUseCase updateUserProfileWithRatingUseCase;
+    private static final String TOPIC = "created-rating";
+    private static final String EVENT_TYPE = "CreatedRatingEvent";
+    private static final String CONSUMER_GROUP = "recommendation-service";
 
-    public CreatedRatingConsumerEvent(UpdateUserProfileWithRatingUseCase updateUserProfileWithRatingUseCase) {
+    private final UpdateUserProfileWithRatingUseCase updateUserProfileWithRatingUseCase;
+    private final VellumHubMetrics metrics;
+
+    public CreatedRatingConsumerEvent(UpdateUserProfileWithRatingUseCase updateUserProfileWithRatingUseCase, VellumHubMetrics metrics) {
         this.updateUserProfileWithRatingUseCase = updateUserProfileWithRatingUseCase;
+        this.metrics = metrics;
     }
 
     @KafkaListener(
@@ -25,6 +33,7 @@ public class CreatedRatingConsumerEvent {
     public void consume(
             @Payload CreatedRatingEvent event
     ) {
+        Timer.Sample sample = metrics.startKafkaProcessing();
         log.info("Event received: Rating created. UserId={}, BookId={}, Stars={}",
                 event.userId(),
                 event.bookId(),
@@ -38,7 +47,15 @@ public class CreatedRatingConsumerEvent {
                 false
         );
 
-        updateUserProfileWithRatingUseCase.execute(command);
+        try {
+            updateUserProfileWithRatingUseCase.execute(command);
+            metrics.recordKafkaConsumed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "success");
+        } catch (RuntimeException ex) {
+            metrics.recordKafkaConsumeFailed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "failure");
+            throw ex;
+        }
 
 
         log.info("Rating event processed successfully. UserId={}, BookId={}",

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/CreatedUserPreferenceConsumerEvent.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/CreatedUserPreferenceConsumerEvent.java
@@ -3,6 +3,8 @@ package com.vellumhub.recommendation_service.module.user_profile.presentation.co
 import com.vellumhub.recommendation_service.module.user_profile.application.command.CreatedUserProfileCommand;
 import com.vellumhub.recommendation_service.module.user_profile.application.use_case.CreateUserProfileUseCase;
 import com.vellumhub.recommendation_service.module.user_profile.presentation.event.CreatedUserPreferenceEvent;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -12,10 +14,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class CreatedUserPreferenceConsumerEvent {
 
-    private final CreateUserProfileUseCase createUserProfileUseCase;
+    private static final String TOPIC = "created-user-preference";
+    private static final String EVENT_TYPE = "CreatedUserPreferenceEvent";
+    private static final String CONSUMER_GROUP = "recommendation_service_group";
 
-    public CreatedUserPreferenceConsumerEvent(CreateUserProfileUseCase createUserProfileUseCase) {
+    private final CreateUserProfileUseCase createUserProfileUseCase;
+    private final VellumHubMetrics metrics;
+
+    public CreatedUserPreferenceConsumerEvent(CreateUserProfileUseCase createUserProfileUseCase, VellumHubMetrics metrics) {
         this.createUserProfileUseCase = createUserProfileUseCase;
+        this.metrics = metrics;
     }
 
     @KafkaListener(
@@ -23,6 +31,7 @@ public class CreatedUserPreferenceConsumerEvent {
             groupId = "recommendation_service_group"
     )
     public void consume(@Payload CreatedUserPreferenceEvent event) {
+        Timer.Sample sample = metrics.startKafkaProcessing();
         log.info(
                 "Consumed CreatedUserPreferenceEvent. operation=kafka_consume, topic=created-user-preference, event_type=CreatedUserPreferenceEvent, userId={}, genreCount={}, aboutPresent={}",
                 event.userId(),
@@ -37,10 +46,14 @@ public class CreatedUserPreferenceConsumerEvent {
                     event.about()
             );
             createUserProfileUseCase.execute(command);
+            metrics.recordKafkaConsumed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "success");
 
             log.info("Successfully processed CreatedUserPreferenceEvent for userId: {}", event.userId());
 
         } catch (Exception e) {
+            metrics.recordKafkaConsumeFailed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "failure");
             log.error("Error processing CreatedUserPreferenceEvent: {}", e.getMessage(), e);
             throw new RuntimeException("Erro ao processar CreatedUserPreferenceEvent", e);
         }

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/UpdateBookProgressConsumerEvent.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/UpdateBookProgressConsumerEvent.java
@@ -3,6 +3,8 @@ package com.vellumhub.recommendation_service.module.user_profile.presentation.co
 import com.vellumhub.recommendation_service.module.user_profile.application.command.UpdateBookProgressCommand;
 import com.vellumhub.recommendation_service.module.user_profile.application.use_case.UpdateBookProgressUseCase;
 import com.vellumhub.recommendation_service.module.user_profile.presentation.event.UpdateBookProgressEvent;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -11,10 +13,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class UpdateBookProgressConsumerEvent {
 
-    private final UpdateBookProgressUseCase updateBookProgressUseCase;
+    private static final String TOPIC = "updated-reading-progress";
+    private static final String EVENT_TYPE = "UpdateBookProgressEvent";
+    private static final String CONSUMER_GROUP = "recommendation-service";
 
-    public UpdateBookProgressConsumerEvent(UpdateBookProgressUseCase updateBookProgressUseCase) {
+    private final UpdateBookProgressUseCase updateBookProgressUseCase;
+    private final VellumHubMetrics metrics;
+
+    public UpdateBookProgressConsumerEvent(UpdateBookProgressUseCase updateBookProgressUseCase, VellumHubMetrics metrics) {
         this.updateBookProgressUseCase = updateBookProgressUseCase;
+        this.metrics = metrics;
     }
 
     @KafkaListener(
@@ -24,6 +32,7 @@ public class UpdateBookProgressConsumerEvent {
     public void consume(
             UpdateBookProgressEvent event
     ) {
+        Timer.Sample sample = metrics.startKafkaProcessing();
 
         log.info("Event received: Update book progress. UserId={}, BookId={}, Progress={}",
                 event.userId(),
@@ -39,7 +48,15 @@ public class UpdateBookProgressConsumerEvent {
                 event.newPage()
         );
 
-        updateBookProgressUseCase.execute(command);
+        try {
+            updateBookProgressUseCase.execute(command);
+            metrics.recordKafkaConsumed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "success");
+        } catch (RuntimeException ex) {
+            metrics.recordKafkaConsumeFailed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "failure");
+            throw ex;
+        }
 
         log.info("Book progress update event processed successfully. UserId={}, BookId={}",
                 event.userId(),

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/UserReactionConsumerEvent.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/UserReactionConsumerEvent.java
@@ -3,6 +3,8 @@ package com.vellumhub.recommendation_service.module.user_profile.presentation.co
 import com.vellumhub.recommendation_service.module.user_profile.application.command.ReactionChangedCommand;
 import com.vellumhub.recommendation_service.module.user_profile.application.use_case.ReactionChangedUseCase;
 import com.vellumhub.recommendation_service.module.user_profile.presentation.event.ReactionChangedEvent;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -11,10 +13,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class UserReactionConsumerEvent {
 
-    private final ReactionChangedUseCase reactionChangedUseCase;
+    private static final String TOPIC = "user-reaction-changed";
+    private static final String EVENT_TYPE = "ReactionChangedEvent";
+    private static final String CONSUMER_GROUP = "recommendation-service";
 
-    public UserReactionConsumerEvent(ReactionChangedUseCase reactionChangedUseCase) {
+    private final ReactionChangedUseCase reactionChangedUseCase;
+    private final VellumHubMetrics metrics;
+
+    public UserReactionConsumerEvent(ReactionChangedUseCase reactionChangedUseCase, VellumHubMetrics metrics) {
         this.reactionChangedUseCase = reactionChangedUseCase;
+        this.metrics = metrics;
     }
 
     @KafkaListener(
@@ -22,6 +30,7 @@ public class UserReactionConsumerEvent {
             groupId = "recommendation-service"
     )
     public void consume(ReactionChangedEvent event) {
+        Timer.Sample sample = metrics.startKafkaProcessing();
         log.info("Event received: User reaction changed. UserId={}, BookId={}, Reaction={}",
                 event.userId(),
                 event.bookId(),
@@ -33,7 +42,15 @@ public class UserReactionConsumerEvent {
                 event.typeReaction()
         );
 
-        reactionChangedUseCase.execute(command);
+        try {
+            reactionChangedUseCase.execute(command);
+            metrics.recordKafkaConsumed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "success");
+        } catch (RuntimeException ex) {
+            metrics.recordKafkaConsumeFailed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "failure");
+            throw ex;
+        }
 
         log.info("User reaction change event processed successfully. UserId={}, BookId={}",
                 event.userId(),

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/config/DltKafkaConsumerConfig.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/config/DltKafkaConsumerConfig.java
@@ -1,0 +1,35 @@
+package com.vellumhub.recommendation_service.share.kafka.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class DltKafkaConsumerConfig {
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, byte[]> dltKafkaListenerContainerFactory(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers
+    ) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+
+        ConsumerFactory<String, byte[]> consumerFactory = new DefaultKafkaConsumerFactory<>(properties);
+        ConcurrentKafkaListenerContainerFactory<String, byte[]> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        return factory;
+    }
+}

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfig.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfig.java
@@ -1,17 +1,27 @@
 package com.vellumhub.recommendation_service.share.kafka.config;
 
 import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.handler.annotation.Header;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
 import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
 import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.serializer.DelegatingByTypeSerializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Configuration
 @Slf4j
@@ -27,11 +37,12 @@ public class KafkaRetryConfig {
 
     /**
      * Defines a default retry configuration for Kafka listeners in the application.
-     * @param template the KafkaTemplate used to send messages to retry topics
      * @return a RetryTopicConfiguration that applies to all specified topics with a fixed backoff strategy and a maximum of 3 attempts.
      */
     @Bean
-    public RetryTopicConfiguration defaultRetryConfig(KafkaTemplate<String, Object> template) {
+    public RetryTopicConfiguration defaultRetryConfig(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers
+    ) {
         return RetryTopicConfigurationBuilder
                 .newInstance()
                 .maxAttempts(3)
@@ -46,7 +57,7 @@ public class KafkaRetryConfig {
                         "updated-reading-progress",
                         "user-reaction-changed"
                 ))
-                .create(template);
+                .create(retryTopicKafkaTemplate(bootstrapServers));
     }
 
     /**
@@ -89,6 +100,22 @@ public class KafkaRetryConfig {
 
     private int payloadByteLength(byte[] payload) {
         return payload == null ? 0 : payload.length;
+    }
+
+    private KafkaTemplate<String, Object> retryTopicKafkaTemplate(String bootstrapServers) {
+        Map<String, Object> properties = Map.of(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        Map<Class<?>, org.apache.kafka.common.serialization.Serializer<?>> delegates = new LinkedHashMap<>();
+        delegates.put(byte[].class, new ByteArraySerializer());
+        delegates.put(String.class, new StringSerializer());
+        delegates.put(Object.class, new JsonSerializer<>());
+
+        ProducerFactory<String, Object> producerFactory = new DefaultKafkaProducerFactory<>(
+                properties,
+                new StringSerializer(),
+                new DelegatingByTypeSerializer(delegates, true)
+        );
+        return new KafkaTemplate<>(producerFactory);
     }
 
 }

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfig.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfig.java
@@ -11,7 +11,6 @@ import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
 import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
 import org.springframework.kafka.support.KafkaHeaders;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Configuration
@@ -50,26 +49,27 @@ public class KafkaRetryConfig {
                 .create(template);
     }
 
-
     /**
      * Listens to all Dead Letter Topics across the microservice.
      * The topicPattern ".*-dlt" ensures any topic ending with "-dlt" is captured here.
      */
     @KafkaListener(
             topicPattern = ".*-dlt",
-            groupId = "recommendation-service-dlt-group"
+            groupId = "recommendation-service-dlt-group",
+            containerFactory = "dltKafkaListenerContainerFactory"
     )
     public void consumeDlt(
-            String payload,
+            byte[] payload,
             @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
-            @Header(KafkaHeaders.ORIGINAL_TOPIC) String originalTopic,
-            @Header(KafkaHeaders.EXCEPTION_MESSAGE) String errorMessage
+            @Header(name = KafkaHeaders.ORIGINAL_TOPIC, required = false) String originalTopic,
+            @Header(name = KafkaHeaders.EXCEPTION_MESSAGE, required = false) String errorMessage
     ) {
 
-        metrics.recordKafkaDlt(originalTopic, DLT_CONSUMER_GROUP);
+        String quarantinedTopic = originalTopic(topic, originalTopic);
+        metrics.recordKafkaDlt(quarantinedTopic, DLT_CONSUMER_GROUP);
         log.error(
                 "Kafka DLT message quarantined. operation=kafka_dlt_quarantine, event_type=kafka_dlt, originalTopic={}, dltTopic={}, error={}, payloadBytes={}",
-                originalTopic,
+                quarantinedTopic,
                 topic,
                 errorMessage,
                 payloadByteLength(payload)
@@ -77,8 +77,18 @@ public class KafkaRetryConfig {
 
     }
 
-    private int payloadByteLength(String payload) {
-        return payload == null ? 0 : payload.getBytes(StandardCharsets.UTF_8).length;
+    private String originalTopic(String dltTopic, String originalTopic) {
+        if (originalTopic != null && !originalTopic.isBlank()) {
+            return originalTopic;
+        }
+        if (dltTopic != null && dltTopic.endsWith("-dlt")) {
+            return dltTopic.substring(0, dltTopic.length() - "-dlt".length());
+        }
+        return "unknown";
+    }
+
+    private int payloadByteLength(byte[] payload) {
+        return payload == null ? 0 : payload.length;
     }
 
 }

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfig.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfig.java
@@ -1,5 +1,6 @@
 package com.vellumhub.recommendation_service.share.kafka.config;
 
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
 import org.springframework.messaging.handler.annotation.Header;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -16,6 +17,14 @@ import java.util.List;
 @Configuration
 @Slf4j
 public class KafkaRetryConfig {
+
+    private static final String DLT_CONSUMER_GROUP = "recommendation-service-dlt-group";
+
+    private final VellumHubMetrics metrics;
+
+    public KafkaRetryConfig(VellumHubMetrics metrics) {
+        this.metrics = metrics;
+    }
 
     /**
      * Defines a default retry configuration for Kafka listeners in the application.
@@ -57,6 +66,7 @@ public class KafkaRetryConfig {
             @Header(KafkaHeaders.EXCEPTION_MESSAGE) String errorMessage
     ) {
 
+        metrics.recordKafkaDlt(originalTopic, DLT_CONSUMER_GROUP);
         log.error(
                 "Kafka DLT message quarantined. operation=kafka_dlt_quarantine, event_type=kafka_dlt, originalTopic={}, dltTopic={}, error={}, payloadBytes={}",
                 originalTopic,

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfig.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfig.java
@@ -47,6 +47,8 @@ public class KafkaRetryConfig {
                 .newInstance()
                 .maxAttempts(3)
                 .fixedBackOff(3000)
+                .doNotRetryOnDltFailure()
+                .autoStartDltHandler(false)
                 .includeTopics(List.of(
                         "created-book",
                         "deleted-book",

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/consumer/CreateBookConsumerEvent.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/consumer/CreateBookConsumerEvent.java
@@ -3,7 +3,9 @@ package com.vellumhub.recommendation_service.share.kafka.consumer;
 import com.vellumhub.recommendation_service.module.book_feature.application.use_case.CreateBookFeatureUseCase;
 import com.vellumhub.recommendation_service.module.recommendation.application.command.CreateRecommendationCommand;
 import com.vellumhub.recommendation_service.module.recommendation.application.use_case.CreateRecommendationUseCase;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
 import com.vellumhub.recommendation_service.share.kafka.event.CreateBookEvent;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -13,12 +15,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class CreateBookConsumerEvent {
 
+    private static final String TOPIC = "created-book";
+    private static final String EVENT_TYPE = "CreateBookEvent";
+    private static final String CONSUMER_GROUP = "recommendation-service";
+
     private final CreateBookFeatureUseCase createBookFeatureUseCase;
     private final CreateRecommendationUseCase createRecommendationUseCase;
+    private final VellumHubMetrics metrics;
 
-    public CreateBookConsumerEvent(CreateBookFeatureUseCase createBookFeatureUseCase, CreateRecommendationUseCase createRecommendationUseCase) {
+    public CreateBookConsumerEvent(CreateBookFeatureUseCase createBookFeatureUseCase, CreateRecommendationUseCase createRecommendationUseCase, VellumHubMetrics metrics) {
         this.createBookFeatureUseCase = createBookFeatureUseCase;
         this.createRecommendationUseCase = createRecommendationUseCase;
+        this.metrics = metrics;
     }
 
 
@@ -28,22 +36,31 @@ public class CreateBookConsumerEvent {
     )
     @Transactional
     public void listen(CreateBookEvent event) {
+        Timer.Sample sample = metrics.startKafkaProcessing();
         log.info("Event received: Book creation. BookId={}, Genres={}",
                 event.bookId(),
                 event.genres());
 
-        createBookFeatureUseCase.execute(event);
+        try {
+            createBookFeatureUseCase.execute(event);
 
-        CreateRecommendationCommand command = CreateRecommendationCommand.of(
-                event.bookId(),
-                event.title(),
-                event.description(),
-                event.releaseYear(),
-                event.coverUrl(),
-                event.author(),
-                event.genres()
-        );
-        createRecommendationUseCase.execute(command);
+            CreateRecommendationCommand command = CreateRecommendationCommand.of(
+                    event.bookId(),
+                    event.title(),
+                    event.description(),
+                    event.releaseYear(),
+                    event.coverUrl(),
+                    event.author(),
+                    event.genres()
+            );
+            createRecommendationUseCase.execute(command);
+            metrics.recordKafkaConsumed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "success");
+        } catch (RuntimeException ex) {
+            metrics.recordKafkaConsumeFailed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "failure");
+            throw ex;
+        }
 
         log.info("Book creation event processed successfully. BookId={}",
                 event.bookId());

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/consumer/DeleteBookConsumerEvent.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/consumer/DeleteBookConsumerEvent.java
@@ -3,7 +3,9 @@ package com.vellumhub.recommendation_service.share.kafka.consumer;
 import com.vellumhub.recommendation_service.module.book_feature.application.use_case.DeleteBookFeatureUseCase;
 import com.vellumhub.recommendation_service.module.recommendation.application.command.DeleteRecommendationCommand;
 import com.vellumhub.recommendation_service.module.recommendation.application.use_case.DeleteRecommendationUseCase;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
 import com.vellumhub.recommendation_service.share.kafka.event.DeleteBookEvent;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -12,12 +14,18 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class DeleteBookConsumerEvent {
 
+    private static final String TOPIC = "deleted-book";
+    private static final String EVENT_TYPE = "DeleteBookEvent";
+    private static final String CONSUMER_GROUP = "recommendation-service";
+
     private final DeleteBookFeatureUseCase deleteBookFeatureUseCase;
     private final DeleteRecommendationUseCase deleteRecommendationUseCase;
+    private final VellumHubMetrics metrics;
 
-    public DeleteBookConsumerEvent(DeleteBookFeatureUseCase deleteBookFeatureUseCase, DeleteRecommendationUseCase deleteRecommendationUseCase) {
+    public DeleteBookConsumerEvent(DeleteBookFeatureUseCase deleteBookFeatureUseCase, DeleteRecommendationUseCase deleteRecommendationUseCase, VellumHubMetrics metrics) {
         this.deleteBookFeatureUseCase = deleteBookFeatureUseCase;
         this.deleteRecommendationUseCase = deleteRecommendationUseCase;
+        this.metrics = metrics;
     }
 
 
@@ -26,13 +34,22 @@ public class DeleteBookConsumerEvent {
             groupId = "recommendation-service"
     )
     public void listen(DeleteBookEvent deleteBookEvent) {
+        Timer.Sample sample = metrics.startKafkaProcessing();
         log.info("Event received: Book deletion. BookId={}",
                 deleteBookEvent.bookId());
 
-        deleteBookFeatureUseCase.execute(deleteBookEvent.bookId());
+        try {
+            deleteBookFeatureUseCase.execute(deleteBookEvent.bookId());
 
-        var command = DeleteRecommendationCommand.of(deleteBookEvent.bookId());
-        deleteRecommendationUseCase.execute(command);
+            var command = DeleteRecommendationCommand.of(deleteBookEvent.bookId());
+            deleteRecommendationUseCase.execute(command);
+            metrics.recordKafkaConsumed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "success");
+        } catch (RuntimeException ex) {
+            metrics.recordKafkaConsumeFailed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "failure");
+            throw ex;
+        }
 
         log.info("Book deletion event processed successfully. BookId={}",
                 deleteBookEvent.bookId());

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/consumer/UpdateBookConsumerEvent.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/kafka/consumer/UpdateBookConsumerEvent.java
@@ -4,7 +4,9 @@ import com.vellumhub.recommendation_service.module.book_feature.application.comm
 import com.vellumhub.recommendation_service.module.book_feature.application.use_case.UpdateBookFeatureUseCase;
 import com.vellumhub.recommendation_service.module.recommendation.application.command.UpdateRecommendationCommand;
 import com.vellumhub.recommendation_service.module.recommendation.application.use_case.UpdateRecommendationUseCase;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
 import com.vellumhub.recommendation_service.share.kafka.event.UpdateBookEvent;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -13,12 +15,18 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class UpdateBookConsumerEvent {
 
+    private static final String TOPIC = "updated-book";
+    private static final String EVENT_TYPE = "UpdateBookEvent";
+    private static final String CONSUMER_GROUP = "recommendation-service";
+
     private final UpdateBookFeatureUseCase updateBookFeatureUseCase;
     private final UpdateRecommendationUseCase updateRecommendationUseCase;
+    private final VellumHubMetrics metrics;
 
-    public UpdateBookConsumerEvent(UpdateBookFeatureUseCase updateBookFeatureUseCase, UpdateRecommendationUseCase updateRecommendationUseCase) {
+    public UpdateBookConsumerEvent(UpdateBookFeatureUseCase updateBookFeatureUseCase, UpdateRecommendationUseCase updateRecommendationUseCase, VellumHubMetrics metrics) {
         this.updateBookFeatureUseCase = updateBookFeatureUseCase;
         this.updateRecommendationUseCase = updateRecommendationUseCase;
+        this.metrics = metrics;
     }
 
     @KafkaListener(
@@ -26,6 +34,7 @@ public class UpdateBookConsumerEvent {
             groupId = "recommendation-service"
     )
     public void execute(UpdateBookEvent event) {
+        Timer.Sample sample = metrics.startKafkaProcessing();
         log.info("Event received: Book update. BookId={}, Genres={}",
                 event.bookId(),
                 event.genres());
@@ -47,8 +56,16 @@ public class UpdateBookConsumerEvent {
                 event.genres()
         );
 
-        updateBookFeatureUseCase.execute(mediaFeatureCommand);
-        updateRecommendationUseCase.execute(updateRecommendationCommand);
+        try {
+            updateBookFeatureUseCase.execute(mediaFeatureCommand);
+            updateRecommendationUseCase.execute(updateRecommendationCommand);
+            metrics.recordKafkaConsumed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "success");
+        } catch (RuntimeException ex) {
+            metrics.recordKafkaConsumeFailed(TOPIC, EVENT_TYPE, CONSUMER_GROUP);
+            metrics.recordKafkaProcessingDuration(sample, TOPIC, EVENT_TYPE, CONSUMER_GROUP, "failure");
+            throw ex;
+        }
 
         log.info("Book update event processed successfully. BookId={}",
                 event.bookId());

--- a/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/metrics/VellumHubMetrics.java
+++ b/services/recommendation-service/src/main/java/com/vellumhub/recommendation_service/share/metrics/VellumHubMetrics.java
@@ -1,0 +1,89 @@
+package com.vellumhub.recommendation_service.share.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class VellumHubMetrics {
+
+    public static final String KAFKA_EVENTS_PUBLISHED = "vellumhub.kafka.events.published";
+    public static final String KAFKA_EVENTS_PUBLISH_FAILED = "vellumhub.kafka.events.publish.failed";
+    public static final String KAFKA_EVENTS_CONSUMED = "vellumhub.kafka.events.consumed";
+    public static final String KAFKA_EVENTS_CONSUME_FAILED = "vellumhub.kafka.events.consume.failed";
+    public static final String KAFKA_EVENT_PROCESSING_DURATION = "vellumhub.kafka.event.processing.duration";
+    public static final String KAFKA_DLT_EVENTS = "vellumhub.kafka.dlt.events";
+
+    public static final String USERS_CREATED = "vellumhub.users.created";
+    public static final String BOOKS_CREATED = "vellumhub.books.created";
+    public static final String BOOKS_UPDATED = "vellumhub.books.updated";
+    public static final String BOOKS_DELETED = "vellumhub.books.deleted";
+    public static final String READING_PROGRESS_UPDATED = "vellumhub.reading.progress.updated";
+    public static final String RATINGS_CREATED = "vellumhub.ratings.created";
+    public static final String REACTIONS_CHANGED = "vellumhub.reactions.changed";
+    public static final String RECOMMENDATIONS_REQUESTED = "vellumhub.recommendations.requested";
+    public static final String RECOMMENDATIONS_GENERATED = "vellumhub.recommendations.generated";
+    public static final String RECOMMENDATION_EMPTY_RESULTS = "vellumhub.recommendation.empty.results";
+    public static final String RECOMMENDATION_GENERATION_DURATION = "vellumhub.recommendation.generation.duration";
+
+    private final MeterRegistry meterRegistry;
+
+    public VellumHubMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = Objects.requireNonNull(meterRegistry, "meterRegistry must not be null");
+    }
+
+    public void recordKafkaPublished(String topic, Object event) {
+        counter(KAFKA_EVENTS_PUBLISHED, "topic", topic, "event_type", eventType(event), "result", "success").increment();
+    }
+
+    public void recordKafkaPublishFailed(String topic, Object event) {
+        counter(KAFKA_EVENTS_PUBLISH_FAILED, "topic", topic, "event_type", eventType(event), "result", "failure").increment();
+    }
+
+    public Timer.Sample startKafkaProcessing() {
+        return Timer.start(meterRegistry);
+    }
+
+    public void recordKafkaConsumed(String topic, String eventType, String consumerGroup) {
+        counter(KAFKA_EVENTS_CONSUMED, "topic", topic, "event_type", eventType, "consumer_group", consumerGroup, "result", "success").increment();
+    }
+
+    public void recordKafkaConsumeFailed(String topic, String eventType, String consumerGroup) {
+        counter(KAFKA_EVENTS_CONSUME_FAILED, "topic", topic, "event_type", eventType, "consumer_group", consumerGroup, "result", "failure").increment();
+    }
+
+    public void recordKafkaProcessingDuration(Timer.Sample sample, String topic, String eventType, String consumerGroup, String result) {
+        sample.stop(Timer.builder(KAFKA_EVENT_PROCESSING_DURATION)
+                .tags("topic", topic, "event_type", eventType, "consumer_group", consumerGroup, "result", result)
+                .register(meterRegistry));
+    }
+
+    public void recordKafkaDlt(String originalTopic, String consumerGroup) {
+        counter(KAFKA_DLT_EVENTS, "topic", originalTopic, "event_type", "kafka_dlt", "consumer_group", consumerGroup, "operation", "kafka_dlt_quarantine", "result", "quarantined").increment();
+    }
+
+    public void recordBusinessCounter(String name, String operation, String result) {
+        counter(name, "operation", operation, "result", result).increment();
+    }
+
+    public Timer.Sample startBusinessTimer() {
+        return Timer.start(meterRegistry);
+    }
+
+    public void recordRecommendationGenerationDuration(Timer.Sample sample, String result) {
+        sample.stop(Timer.builder(RECOMMENDATION_GENERATION_DURATION)
+                .tags("operation", "recommendation_generation", "result", result)
+                .register(meterRegistry));
+    }
+
+    private Counter counter(String name, String... tags) {
+        return Counter.builder(name).tags(tags).register(meterRegistry);
+    }
+
+    private String eventType(Object event) {
+        return event == null ? "unknown" : event.getClass().getSimpleName();
+    }
+}

--- a/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/module/recommendation/application/use_case/GetRecommendationsUseCaseTest.java
+++ b/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/module/recommendation/application/use_case/GetRecommendationsUseCaseTest.java
@@ -4,10 +4,12 @@ import com.vellumhub.recommendation_service.module.book_feature.domain.port.Book
 import com.vellumhub.recommendation_service.module.recommendation.application.command.GetRecommendationsCommand;
 import com.vellumhub.recommendation_service.module.recommendation.domain.model.Recommendation;
 import com.vellumhub.recommendation_service.module.recommendation.domain.port.RecommendationRepository;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -27,8 +29,19 @@ class GetRecommendationsUseCaseTest {
     @Mock
     private RecommendationRepository recommendationRepository;
 
-    @InjectMocks
     private GetRecommendationsUseCase getRecommendationsUseCase;
+
+    private SimpleMeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        getRecommendationsUseCase = new GetRecommendationsUseCase(
+                bookFeatureRepository,
+                recommendationRepository,
+                new VellumHubMetrics(meterRegistry)
+        );
+    }
 
     @Test
     @DisplayName("Should return recommendations based on user's book interactions")
@@ -52,6 +65,8 @@ class GetRecommendationsUseCaseTest {
         verify(bookFeatureRepository).findAllByUserId(userId, 10, 0);
         verify(recommendationRepository).findAllById(userBookIds);
         verify(bookFeatureRepository, never()).findMostPopularMedias(anyInt(), anyInt());
+        assertThat(recommendationsGeneratedCount()).isEqualTo(1.0);
+        assertThat(recommendationGenerationTimerCount("success")).isEqualTo(1L);
     }
 
     @Test
@@ -73,6 +88,8 @@ class GetRecommendationsUseCaseTest {
         // Assert
         assertThat(result).containsExactly(popularRec);
         verify(bookFeatureRepository).findMostPopularMedias(5, 0);
+        assertThat(recommendationsGeneratedCount()).isEqualTo(1.0);
+        assertThat(recommendationGenerationTimerCount("success")).isEqualTo(1L);
     }
 
     @Test
@@ -93,6 +110,8 @@ class GetRecommendationsUseCaseTest {
         // Assert
         assertThat(result).isEmpty();
         verify(bookFeatureRepository).findMostPopularMedias(5, 0);
+        assertThat(emptyRecommendationsCount()).isEqualTo(1.0);
+        assertThat(recommendationGenerationTimerCount("empty")).isEqualTo(1L);
     }
 
     private Recommendation createRecommendation(String title) {
@@ -105,5 +124,29 @@ class GetRecommendationsUseCaseTest {
                 "Author",
                 Collections.emptyList()
         );
+    }
+
+    private double recommendationsGeneratedCount() {
+        return meterRegistry.get(VellumHubMetrics.RECOMMENDATIONS_GENERATED)
+                .tag("operation", "recommendation_generation")
+                .tag("result", "success")
+                .counter()
+                .count();
+    }
+
+    private double emptyRecommendationsCount() {
+        return meterRegistry.get(VellumHubMetrics.RECOMMENDATION_EMPTY_RESULTS)
+                .tag("operation", "recommendation_generation")
+                .tag("result", "empty")
+                .counter()
+                .count();
+    }
+
+    private long recommendationGenerationTimerCount(String result) {
+        return meterRegistry.get(VellumHubMetrics.RECOMMENDATION_GENERATION_DURATION)
+                .tag("operation", "recommendation_generation")
+                .tag("result", result)
+                .timer()
+                .count();
     }
 }

--- a/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/module/recommendation/presentation/controller/RecommendationControllerTest.java
+++ b/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/module/recommendation/presentation/controller/RecommendationControllerTest.java
@@ -6,12 +6,14 @@ import com.vellumhub.recommendation_service.module.recommendation.domain.model.R
 import com.vellumhub.recommendation_service.module.recommendation.presentation.dto.RecommendationResponse;
 import com.vellumhub.recommendation_service.module.recommendation.presentation.mapper.RecommendationMapper;
 import com.vellumhub.recommendation_service.share.provider.UserAuthenticationProvider;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -36,11 +38,23 @@ class RecommendationControllerTest {
     @Mock
     private GetRecommendationsUseCase getRecommendationsUseCase;
 
-    @InjectMocks
     private RecommendationController controller;
+
+    private SimpleMeterRegistry meterRegistry;
 
     @Captor
     private ArgumentCaptor<GetRecommendationsCommand> commandCaptor;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        controller = new RecommendationController(
+                userAuthenticationProvider,
+                mapper,
+                getRecommendationsUseCase,
+                new VellumHubMetrics(meterRegistry)
+        );
+    }
 
     private Recommendation buildRecommendation(UUID bookId, String title) {
         return Recommendation.builder()
@@ -71,6 +85,7 @@ class RecommendationControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).hasSize(1);
         assertThat(response.getBody().get(0).title()).isEqualTo("Book A");
+        assertThat(recommendationRequestsCount()).isEqualTo(1.0);
     }
 
     @Test
@@ -120,5 +135,13 @@ class RecommendationControllerTest {
 
         assertThat(response.getBody()).hasSize(2);
         verify(mapper, times(2)).toResponse(any());
+    }
+
+    private double recommendationRequestsCount() {
+        return meterRegistry.get(VellumHubMetrics.RECOMMENDATIONS_REQUESTED)
+                .tag("operation", "recommendation_request")
+                .tag("result", "success")
+                .counter()
+                .count();
     }
 }

--- a/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/CreatedRatingConsumerEventTest.java
+++ b/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/CreatedRatingConsumerEventTest.java
@@ -3,6 +3,7 @@ package com.vellumhub.recommendation_service.module.user_profile.presentation.co
 import com.vellumhub.recommendation_service.module.user_profile.application.command.UpdateUserProfileWithRatingCommand;
 import com.vellumhub.recommendation_service.module.user_profile.application.use_case.UpdateUserProfileWithRatingUseCase;
 import com.vellumhub.recommendation_service.module.user_profile.presentation.event.CreatedRatingEvent;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +25,9 @@ class CreatedRatingConsumerEventTest {
 
     @Mock
     private UpdateUserProfileWithRatingUseCase updateUserProfileWithRatingUseCase;
+
+    @Mock
+    private VellumHubMetrics metrics;
 
     @InjectMocks
     private CreatedRatingConsumerEvent createdRatingConsumerEvent;

--- a/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/CreatedUserPreferenceConsumerEventTest.java
+++ b/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/CreatedUserPreferenceConsumerEventTest.java
@@ -3,6 +3,7 @@ package com.vellumhub.recommendation_service.module.user_profile.presentation.co
 import com.vellumhub.recommendation_service.module.user_profile.application.command.CreatedUserProfileCommand;
 import com.vellumhub.recommendation_service.module.user_profile.application.use_case.CreateUserProfileUseCase;
 import com.vellumhub.recommendation_service.module.user_profile.presentation.event.CreatedUserPreferenceEvent;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +26,9 @@ class CreatedUserPreferenceConsumerEventTest {
 
     @Mock
     private CreateUserProfileUseCase createUserProfileUseCase;
+
+    @Mock
+    private VellumHubMetrics metrics;
 
     @InjectMocks
     private CreatedUserPreferenceConsumerEvent createdUserPreferenceConsumerEvent;

--- a/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/UpdateBookProgressConsumerEventTest.java
+++ b/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/UpdateBookProgressConsumerEventTest.java
@@ -3,6 +3,7 @@ package com.vellumhub.recommendation_service.module.user_profile.presentation.co
 import com.vellumhub.recommendation_service.module.user_profile.application.command.UpdateBookProgressCommand;
 import com.vellumhub.recommendation_service.module.user_profile.application.use_case.UpdateBookProgressUseCase;
 import com.vellumhub.recommendation_service.module.user_profile.presentation.event.UpdateBookProgressEvent;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +25,9 @@ class UpdateBookProgressConsumerEventTest {
 
     @Mock
     private UpdateBookProgressUseCase updateBookProgressUseCase;
+
+    @Mock
+    private VellumHubMetrics metrics;
 
     @InjectMocks
     private UpdateBookProgressConsumerEvent updateBookProgressConsumerEvent;

--- a/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/UserReactionConsumerEventTest.java
+++ b/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/module/user_profile/presentation/consumer/UserReactionConsumerEventTest.java
@@ -3,6 +3,7 @@ package com.vellumhub.recommendation_service.module.user_profile.presentation.co
 import com.vellumhub.recommendation_service.module.user_profile.application.command.ReactionChangedCommand;
 import com.vellumhub.recommendation_service.module.user_profile.application.use_case.ReactionChangedUseCase;
 import com.vellumhub.recommendation_service.module.user_profile.presentation.event.ReactionChangedEvent;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +25,9 @@ class UserReactionConsumerEventTest {
 
     @Mock
     private ReactionChangedUseCase reactionChangedUseCase;
+
+    @Mock
+    private VellumHubMetrics metrics;
 
     @InjectMocks
     private UserReactionConsumerEvent userReactionConsumerEvent;

--- a/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfigTest.java
+++ b/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfigTest.java
@@ -1,5 +1,7 @@
 package com.vellumhub.recommendation_service.share.kafka.config;
 
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.system.CapturedOutput;
@@ -12,7 +14,7 @@ class KafkaRetryConfigTest {
 
     @Test
     void dltLoggingDoesNotExposeRawPayload(CapturedOutput output) {
-        KafkaRetryConfig config = new KafkaRetryConfig();
+        KafkaRetryConfig config = new KafkaRetryConfig(new VellumHubMetrics(new SimpleMeterRegistry()));
 
         config.consumeDlt(
                 "{\"password\":\"secret\",\"token\":\"full.jwt.value\"}",
@@ -30,5 +32,19 @@ class KafkaRetryConfigTest {
                 .doesNotContain("secret")
                 .doesNotContain("full.jwt.value")
                 .doesNotContain("Message Payload");
+    }
+
+    @Test
+    void dltConsumerCountsQuarantinedEvents() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        KafkaRetryConfig config = new KafkaRetryConfig(new VellumHubMetrics(meterRegistry));
+
+        config.consumeDlt("{}", "created-book-dlt", "created-book", "boom");
+
+        assertThat(meterRegistry.get("vellumhub.kafka.dlt.events")
+                .tag("topic", "created-book")
+                .tag("consumer_group", "recommendation-service-dlt-group")
+                .counter()
+                .count()).isEqualTo(1.0);
     }
 }

--- a/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfigTest.java
+++ b/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfigTest.java
@@ -63,4 +63,16 @@ class KafkaRetryConfigTest {
                 .counter()
                 .count()).isEqualTo(1.0);
     }
+
+    @Test
+    void retryTopicDltHandlersAreNotAutoStarted() {
+        KafkaRetryConfig config = new KafkaRetryConfig(new VellumHubMetrics(new SimpleMeterRegistry()));
+
+        var retryConfig = config.defaultRetryConfig("localhost:9092");
+
+        assertThat(retryConfig.getDestinationTopicProperties())
+                .filteredOn(properties -> properties.isDltTopic())
+                .isNotEmpty()
+                .allSatisfy(properties -> assertThat(properties.autoStartDltHandler()).isFalse());
+    }
 }

--- a/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfigTest.java
+++ b/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/kafka/config/KafkaRetryConfigTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(OutputCaptureExtension.class)
@@ -17,7 +19,7 @@ class KafkaRetryConfigTest {
         KafkaRetryConfig config = new KafkaRetryConfig(new VellumHubMetrics(new SimpleMeterRegistry()));
 
         config.consumeDlt(
-                "{\"password\":\"secret\",\"token\":\"full.jwt.value\"}",
+                "{\"password\":\"secret\",\"token\":\"full.jwt.value\"}".getBytes(StandardCharsets.UTF_8),
                 "created-book-dlt",
                 "created-book",
                 "boom"
@@ -39,10 +41,24 @@ class KafkaRetryConfigTest {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         KafkaRetryConfig config = new KafkaRetryConfig(new VellumHubMetrics(meterRegistry));
 
-        config.consumeDlt("{}", "created-book-dlt", "created-book", "boom");
+        config.consumeDlt("{}".getBytes(StandardCharsets.UTF_8), "created-book-dlt", "created-book", "boom");
 
         assertThat(meterRegistry.get("vellumhub.kafka.dlt.events")
                 .tag("topic", "created-book")
+                .tag("consumer_group", "recommendation-service-dlt-group")
+                .counter()
+                .count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void dltConsumerFallsBackToDltTopicWhenOriginalTopicHeaderIsMissing() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        KafkaRetryConfig config = new KafkaRetryConfig(new VellumHubMetrics(meterRegistry));
+
+        config.consumeDlt("{}".getBytes(StandardCharsets.UTF_8), "created-rating-dlt", null, null);
+
+        assertThat(meterRegistry.get("vellumhub.kafka.dlt.events")
+                .tag("topic", "created-rating")
                 .tag("consumer_group", "recommendation-service-dlt-group")
                 .counter()
                 .count()).isEqualTo(1.0);

--- a/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/kafka/consumer/CreateBookConsumerEventTest.java
+++ b/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/kafka/consumer/CreateBookConsumerEventTest.java
@@ -3,13 +3,15 @@ package com.vellumhub.recommendation_service.share.kafka.consumer;
 import com.vellumhub.recommendation_service.module.book_feature.application.use_case.CreateBookFeatureUseCase;
 import com.vellumhub.recommendation_service.module.recommendation.application.command.CreateRecommendationCommand;
 import com.vellumhub.recommendation_service.module.recommendation.application.use_case.CreateRecommendationUseCase;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
 import com.vellumhub.recommendation_service.share.kafka.event.CreateBookEvent;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -30,11 +32,21 @@ class CreateBookConsumerEventTest {
     @Mock
     private CreateRecommendationUseCase createRecommendationUseCase;
 
-    @InjectMocks
     private CreateBookConsumerEvent createBookConsumerEvent;
+    private SimpleMeterRegistry meterRegistry;
 
     @Captor
     private ArgumentCaptor<CreateRecommendationCommand> commandCaptor;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        createBookConsumerEvent = new CreateBookConsumerEvent(
+                createBookFeatureUseCase,
+                createRecommendationUseCase,
+                new VellumHubMetrics(meterRegistry)
+        );
+    }
 
     private CreateBookEvent buildEvent() {
         return new CreateBookEvent(
@@ -89,5 +101,52 @@ class CreateBookConsumerEventTest {
                 .hasMessage("Embedding error");
 
         verify(createRecommendationUseCase, never()).execute(any());
+    }
+
+    @Test
+    @DisplayName("Should count successful consumption and processing duration")
+    void shouldCountSuccessfulConsumptionAndDuration() {
+        CreateBookEvent event = buildEvent();
+
+        createBookConsumerEvent.listen(event);
+
+        assertThat(meterRegistry.get("vellumhub.kafka.events.consumed")
+                .tag("topic", "created-book")
+                .tag("event_type", "CreateBookEvent")
+                .tag("consumer_group", "recommendation-service")
+                .counter()
+                .count()).isEqualTo(1.0);
+        assertThat(meterRegistry.get("vellumhub.kafka.event.processing.duration")
+                .tag("topic", "created-book")
+                .tag("event_type", "CreateBookEvent")
+                .tag("consumer_group", "recommendation-service")
+                .tag("result", "success")
+                .timer()
+                .count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Should count failed consumption and processing duration")
+    void shouldCountFailedConsumptionAndDuration() {
+        CreateBookEvent event = buildEvent();
+        doThrow(new RuntimeException("Embedding error")).when(createBookFeatureUseCase).execute(event);
+
+        assertThatThrownBy(() -> createBookConsumerEvent.listen(event))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Embedding error");
+
+        assertThat(meterRegistry.get("vellumhub.kafka.events.consume.failed")
+                .tag("topic", "created-book")
+                .tag("event_type", "CreateBookEvent")
+                .tag("consumer_group", "recommendation-service")
+                .counter()
+                .count()).isEqualTo(1.0);
+        assertThat(meterRegistry.get("vellumhub.kafka.event.processing.duration")
+                .tag("topic", "created-book")
+                .tag("event_type", "CreateBookEvent")
+                .tag("consumer_group", "recommendation-service")
+                .tag("result", "failure")
+                .timer()
+                .count()).isEqualTo(1);
     }
 }

--- a/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/kafka/consumer/DeleteBookConsumerEventTest.java
+++ b/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/kafka/consumer/DeleteBookConsumerEventTest.java
@@ -3,6 +3,7 @@ package com.vellumhub.recommendation_service.share.kafka.consumer;
 import com.vellumhub.recommendation_service.module.book_feature.application.use_case.DeleteBookFeatureUseCase;
 import com.vellumhub.recommendation_service.module.recommendation.application.command.DeleteRecommendationCommand;
 import com.vellumhub.recommendation_service.module.recommendation.application.use_case.DeleteRecommendationUseCase;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
 import com.vellumhub.recommendation_service.share.kafka.event.DeleteBookEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,9 @@ class DeleteBookConsumerEventTest {
 
     @Mock
     private DeleteRecommendationUseCase deleteRecommendationUseCase;
+
+    @Mock
+    private VellumHubMetrics metrics;
 
     @InjectMocks
     private DeleteBookConsumerEvent deleteBookConsumerEvent;

--- a/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/kafka/consumer/UpdateBookConsumerEventTest.java
+++ b/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/kafka/consumer/UpdateBookConsumerEventTest.java
@@ -4,6 +4,7 @@ import com.vellumhub.recommendation_service.module.book_feature.application.comm
 import com.vellumhub.recommendation_service.module.book_feature.application.use_case.UpdateBookFeatureUseCase;
 import com.vellumhub.recommendation_service.module.recommendation.application.command.UpdateRecommendationCommand;
 import com.vellumhub.recommendation_service.module.recommendation.application.use_case.UpdateRecommendationUseCase;
+import com.vellumhub.recommendation_service.share.metrics.VellumHubMetrics;
 import com.vellumhub.recommendation_service.share.kafka.event.UpdateBookEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,9 @@ class UpdateBookConsumerEventTest {
 
     @Mock
     private UpdateRecommendationUseCase updateRecommendationUseCase;
+
+    @Mock
+    private VellumHubMetrics metrics;
 
     @InjectMocks
     private UpdateBookConsumerEvent updateBookConsumerEvent;

--- a/services/user-service/pom.xml
+++ b/services/user-service/pom.xml
@@ -151,6 +151,21 @@
 						</path>
 					</annotationProcessorPaths>
 				</configuration>
+				<executions>
+					<execution>
+						<id>default-testCompile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+						<configuration>
+							<compileSourceRoots>
+								<compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
+								<compileSourceRoot>${project.basedir}/src/test/java</compileSourceRoot>
+							</compileSourceRoots>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/services/user-service/src/main/java/com/vellumhub/user_service/module/auth/domain/handler/RegisterUserHandler.java
+++ b/services/user-service/src/main/java/com/vellumhub/user_service/module/auth/domain/handler/RegisterUserHandler.java
@@ -3,6 +3,7 @@ package com.vellumhub.user_service.module.auth.domain.handler;
 import com.vellumhub.user_service.module.auth.domain.exception.AuthDomainException;
 import com.vellumhub.user_service.module.user.domain.UserEntity;
 import com.vellumhub.user_service.module.user.domain.port.UserRepository;
+import com.vellumhub.user_service.share.metrics.VellumHubMetrics;
 import org.passay.PasswordData;
 import org.passay.PasswordValidator;
 import org.passay.RuleResult;
@@ -16,11 +17,13 @@ public class RegisterUserHandler {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final PasswordValidator passwordValidator;
+    private final VellumHubMetrics metrics;
 
-    public RegisterUserHandler(UserRepository userRepository, PasswordEncoder passwordEncoder, PasswordValidator passwordValidator) {
+    public RegisterUserHandler(UserRepository userRepository, PasswordEncoder passwordEncoder, PasswordValidator passwordValidator, VellumHubMetrics metrics) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.passwordValidator = passwordValidator;
+        this.metrics = metrics;
     }
 
     @Transactional
@@ -38,6 +41,7 @@ public class RegisterUserHandler {
         userEntity.setPassword(passwordEncoder.encode(rawPassword));
 
         userRepository.save(userEntity);
+        metrics.recordBusinessCounter(VellumHubMetrics.USERS_CREATED, "user_registration", "success");
     }
 
     private void validatePassword(String password) {

--- a/services/user-service/src/main/java/com/vellumhub/user_service/module/user/domain/handler/CreateUserHandler.java
+++ b/services/user-service/src/main/java/com/vellumhub/user_service/module/user/domain/handler/CreateUserHandler.java
@@ -3,6 +3,7 @@ package com.vellumhub.user_service.module.user.domain.handler;
 import com.vellumhub.user_service.module.user.domain.exception.UserNotUniqueException;
 import com.vellumhub.user_service.module.user.domain.UserEntity;
 import com.vellumhub.user_service.module.user.domain.port.UserRepository;
+import com.vellumhub.user_service.share.metrics.VellumHubMetrics;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,10 +13,12 @@ public class CreateUserHandler {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final VellumHubMetrics metrics;
 
-    public CreateUserHandler(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    public CreateUserHandler(UserRepository userRepository, PasswordEncoder passwordEncoder, VellumHubMetrics metrics) {
         this.userRepository = userRepository;
         this. passwordEncoder = passwordEncoder;
+        this.metrics = metrics;
     }
 
     @Transactional
@@ -27,5 +30,6 @@ public class CreateUserHandler {
         user.setPassword(passwordEncoder.encode(user.getPassword()));
 
         userRepository.save(user);
+        metrics.recordBusinessCounter(VellumHubMetrics.USERS_CREATED, "admin_user_creation", "success");
     }
 }

--- a/services/user-service/src/main/java/com/vellumhub/user_service/module/user_preference/application/use_case/CreateUserPreferenceUseCase.java
+++ b/services/user-service/src/main/java/com/vellumhub/user_service/module/user_preference/application/use_case/CreateUserPreferenceUseCase.java
@@ -7,6 +7,7 @@ import com.vellumhub.user_service.module.user_preference.application.command.Cre
 import com.vellumhub.user_service.module.user_preference.domain.event.CreateUserPreferenceEvent;
 import com.vellumhub.user_service.module.user_preference.domain.model.UserPreference;
 import com.vellumhub.user_service.module.user_preference.domain.port.UserPreferenceRepository;
+import com.vellumhub.user_service.share.metrics.VellumHubMetrics;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,11 +25,13 @@ public class CreateUserPreferenceUseCase {
     private final UserRepository userRepository;
 
     private final KafkaTemplate<String, CreateUserPreferenceEvent> kafkaTemplate;
+    private final VellumHubMetrics metrics;
 
-    public CreateUserPreferenceUseCase(UserPreferenceRepository userPreferenceRepository, UserRepository userRepository, KafkaTemplate<String, CreateUserPreferenceEvent> kafkaTemplate) {
+    public CreateUserPreferenceUseCase(UserPreferenceRepository userPreferenceRepository, UserRepository userRepository, KafkaTemplate<String, CreateUserPreferenceEvent> kafkaTemplate, VellumHubMetrics metrics) {
         this.userPreferenceRepository = userPreferenceRepository;
         this.userRepository = userRepository;
         this.kafkaTemplate = kafkaTemplate;
+        this.metrics = metrics;
     }
 
     /**
@@ -54,7 +57,14 @@ public class CreateUserPreferenceUseCase {
                 userPreference.getAbout()
         );
 
-        kafkaTemplate.send("created-user-preference", createUserPreferenceEvent.userId().toString(), createUserPreferenceEvent);
+        kafkaTemplate.send("created-user-preference", createUserPreferenceEvent.userId().toString(), createUserPreferenceEvent)
+                .whenComplete((result, ex) -> {
+                    if (ex == null) {
+                        metrics.recordKafkaPublished("created-user-preference", createUserPreferenceEvent);
+                    } else {
+                        metrics.recordKafkaPublishFailed("created-user-preference", createUserPreferenceEvent);
+                    }
+                });
 
     }
 

--- a/services/user-service/src/main/java/com/vellumhub/user_service/share/metrics/VellumHubMetrics.java
+++ b/services/user-service/src/main/java/com/vellumhub/user_service/share/metrics/VellumHubMetrics.java
@@ -1,0 +1,89 @@
+package com.vellumhub.user_service.share.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class VellumHubMetrics {
+
+    public static final String KAFKA_EVENTS_PUBLISHED = "vellumhub.kafka.events.published";
+    public static final String KAFKA_EVENTS_PUBLISH_FAILED = "vellumhub.kafka.events.publish.failed";
+    public static final String KAFKA_EVENTS_CONSUMED = "vellumhub.kafka.events.consumed";
+    public static final String KAFKA_EVENTS_CONSUME_FAILED = "vellumhub.kafka.events.consume.failed";
+    public static final String KAFKA_EVENT_PROCESSING_DURATION = "vellumhub.kafka.event.processing.duration";
+    public static final String KAFKA_DLT_EVENTS = "vellumhub.kafka.dlt.events";
+
+    public static final String USERS_CREATED = "vellumhub.users.created";
+    public static final String BOOKS_CREATED = "vellumhub.books.created";
+    public static final String BOOKS_UPDATED = "vellumhub.books.updated";
+    public static final String BOOKS_DELETED = "vellumhub.books.deleted";
+    public static final String READING_PROGRESS_UPDATED = "vellumhub.reading.progress.updated";
+    public static final String RATINGS_CREATED = "vellumhub.ratings.created";
+    public static final String REACTIONS_CHANGED = "vellumhub.reactions.changed";
+    public static final String RECOMMENDATIONS_REQUESTED = "vellumhub.recommendations.requested";
+    public static final String RECOMMENDATIONS_GENERATED = "vellumhub.recommendations.generated";
+    public static final String RECOMMENDATION_EMPTY_RESULTS = "vellumhub.recommendation.empty.results";
+    public static final String RECOMMENDATION_GENERATION_DURATION = "vellumhub.recommendation.generation.duration";
+
+    private final MeterRegistry meterRegistry;
+
+    public VellumHubMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = Objects.requireNonNull(meterRegistry, "meterRegistry must not be null");
+    }
+
+    public void recordKafkaPublished(String topic, Object event) {
+        counter(KAFKA_EVENTS_PUBLISHED, "topic", topic, "event_type", eventType(event), "result", "success").increment();
+    }
+
+    public void recordKafkaPublishFailed(String topic, Object event) {
+        counter(KAFKA_EVENTS_PUBLISH_FAILED, "topic", topic, "event_type", eventType(event), "result", "failure").increment();
+    }
+
+    public Timer.Sample startKafkaProcessing() {
+        return Timer.start(meterRegistry);
+    }
+
+    public void recordKafkaConsumed(String topic, String eventType, String consumerGroup) {
+        counter(KAFKA_EVENTS_CONSUMED, "topic", topic, "event_type", eventType, "consumer_group", consumerGroup, "result", "success").increment();
+    }
+
+    public void recordKafkaConsumeFailed(String topic, String eventType, String consumerGroup) {
+        counter(KAFKA_EVENTS_CONSUME_FAILED, "topic", topic, "event_type", eventType, "consumer_group", consumerGroup, "result", "failure").increment();
+    }
+
+    public void recordKafkaProcessingDuration(Timer.Sample sample, String topic, String eventType, String consumerGroup, String result) {
+        sample.stop(Timer.builder(KAFKA_EVENT_PROCESSING_DURATION)
+                .tags("topic", topic, "event_type", eventType, "consumer_group", consumerGroup, "result", result)
+                .register(meterRegistry));
+    }
+
+    public void recordKafkaDlt(String originalTopic, String consumerGroup) {
+        counter(KAFKA_DLT_EVENTS, "topic", originalTopic, "event_type", "kafka_dlt", "consumer_group", consumerGroup, "operation", "kafka_dlt_quarantine", "result", "quarantined").increment();
+    }
+
+    public void recordBusinessCounter(String name, String operation, String result) {
+        counter(name, "operation", operation, "result", result).increment();
+    }
+
+    public Timer.Sample startBusinessTimer() {
+        return Timer.start(meterRegistry);
+    }
+
+    public void recordRecommendationGenerationDuration(Timer.Sample sample, String result) {
+        sample.stop(Timer.builder(RECOMMENDATION_GENERATION_DURATION)
+                .tags("operation", "recommendation_generation", "result", result)
+                .register(meterRegistry));
+    }
+
+    private Counter counter(String name, String... tags) {
+        return Counter.builder(name).tags(tags).register(meterRegistry);
+    }
+
+    private String eventType(Object event) {
+        return event == null ? "unknown" : event.getClass().getSimpleName();
+    }
+}

--- a/services/user-service/src/test/java/com/vellumhub/user_service/handler/auth/RegisterUserHandlerTest.java
+++ b/services/user-service/src/test/java/com/vellumhub/user_service/handler/auth/RegisterUserHandlerTest.java
@@ -5,11 +5,13 @@ import com.vellumhub.user_service.module.auth.domain.handler.RegisterUserHandler
 import com.vellumhub.user_service.module.user.domain.RoleUser;
 import com.vellumhub.user_service.module.user.domain.UserEntity;
 import com.vellumhub.user_service.module.user.domain.port.UserRepository;
+import com.vellumhub.user_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.passay.PasswordData;
@@ -33,8 +35,20 @@ class RegisterUserHandlerTest {
     @Mock
     private PasswordValidator passwordValidator;
 
-    @InjectMocks
     private RegisterUserHandler registerUserHandler;
+
+    private SimpleMeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        registerUserHandler = new RegisterUserHandler(
+                userRepository,
+                passwordEncoder,
+                passwordValidator,
+                new VellumHubMetrics(meterRegistry)
+        );
+    }
 
     @Test
     @DisplayName("Should register user when data is valid")
@@ -62,6 +76,7 @@ class RegisterUserHandlerTest {
 
         UserEntity savedUser = userCaptor.getValue();
         assertEquals("encodedPassword", savedUser.getPassword());
+        assertEquals(1.0, usersCreatedCount("user_registration"));
     }
 
     @Test
@@ -148,5 +163,13 @@ class RegisterUserHandlerTest {
         verify(userRepository).save(userCaptor.capture());
 
         assertEquals(encodedPassword, userCaptor.getValue().getPassword());
+    }
+
+    private double usersCreatedCount(String operation) {
+        return meterRegistry.get(VellumHubMetrics.USERS_CREATED)
+                .tag("operation", operation)
+                .tag("result", "success")
+                .counter()
+                .count();
     }
 }

--- a/services/user-service/src/test/java/com/vellumhub/user_service/handler/user/CreateUserHandlerTest.java
+++ b/services/user-service/src/test/java/com/vellumhub/user_service/handler/user/CreateUserHandlerTest.java
@@ -4,10 +4,12 @@ import com.vellumhub.user_service.module.user.domain.UserEntity;
 import com.vellumhub.user_service.module.user.domain.exception.UserNotUniqueException;
 import com.vellumhub.user_service.module.user.domain.handler.CreateUserHandler;
 import com.vellumhub.user_service.module.user.domain.port.UserRepository;
+import com.vellumhub.user_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -25,8 +27,19 @@ class CreateUserHandlerTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
-    @InjectMocks
     private CreateUserHandler createUserHandler;
+
+    private SimpleMeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        createUserHandler = new CreateUserHandler(
+                userRepository,
+                passwordEncoder,
+                new VellumHubMetrics(meterRegistry)
+        );
+    }
 
     @Test
     @DisplayName("Deve salvar usuário com sucesso quando os dados forem válidos")
@@ -46,6 +59,7 @@ class CreateUserHandlerTest {
         verify(userRepository, times(1)).save(user);
         verify(passwordEncoder, times(1)).encode("rawPassword");
         assertEquals("encodedPassword", user.getPassword());
+        assertEquals(1.0, usersCreatedCount("admin_user_creation"));
     }
 
     @Test
@@ -63,5 +77,13 @@ class CreateUserHandlerTest {
                 .hasMessage("User is not unique.");
 
         verify(userRepository, never()).save(any());
+    }
+
+    private double usersCreatedCount(String operation) {
+        return meterRegistry.get(VellumHubMetrics.USERS_CREATED)
+                .tag("operation", operation)
+                .tag("result", "success")
+                .counter()
+                .count();
     }
 }

--- a/services/user-service/src/test/java/com/vellumhub/user_service/module/user_preference/application/use_case/CreateUserPreferenceUseCaseTest.java
+++ b/services/user-service/src/test/java/com/vellumhub/user_service/module/user_preference/application/use_case/CreateUserPreferenceUseCaseTest.java
@@ -7,15 +7,17 @@ import com.vellumhub.user_service.module.user_preference.application.command.Cre
 import com.vellumhub.user_service.module.user_preference.domain.event.CreateUserPreferenceEvent;
 import com.vellumhub.user_service.module.user_preference.domain.model.UserPreference;
 import com.vellumhub.user_service.module.user_preference.domain.port.UserPreferenceRepository;
+import com.vellumhub.user_service.share.metrics.VellumHubMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.core.KafkaTemplate;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -38,8 +40,8 @@ class CreateUserPreferenceUseCaseTest {
     @Mock
     private KafkaTemplate<String, CreateUserPreferenceEvent> kafkaTemplate;
 
-    @InjectMocks
     private CreateUserPreferenceUseCase createUserPreferenceUseCase;
+    private SimpleMeterRegistry meterRegistry;
 
     private UUID userId;
     private UserEntity user;
@@ -50,6 +52,13 @@ class CreateUserPreferenceUseCaseTest {
         userId = UUID.randomUUID();
         user = mock(UserEntity.class);
         command = new CreateUserPreferenceCommand(userId, List.of("FANTASY", "SCIENCE_FICTION"), "I love sci-fi books");
+        meterRegistry = new SimpleMeterRegistry();
+        createUserPreferenceUseCase = new CreateUserPreferenceUseCase(
+                userPreferenceRepository,
+                userRepository,
+                kafkaTemplate,
+                new VellumHubMetrics(meterRegistry)
+        );
     }
 
     @Test
@@ -68,6 +77,7 @@ class CreateUserPreferenceUseCaseTest {
         when(user.getId()).thenReturn(userId);
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userPreferenceRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        stubKafkaSendSuccess();
 
         createUserPreferenceUseCase.execute(command);
 
@@ -92,6 +102,7 @@ class CreateUserPreferenceUseCaseTest {
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userPreferenceRepository.findByUserId(userId)).thenReturn(Optional.of(existing));
+        stubKafkaSendSuccess();
 
         createUserPreferenceUseCase.execute(command);
 
@@ -109,10 +120,11 @@ class CreateUserPreferenceUseCaseTest {
         when(user.getId()).thenReturn(userId);
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userPreferenceRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        stubKafkaSendSuccess();
 
         createUserPreferenceUseCase.execute(command);
 
-        verify(kafkaTemplate).send(eq("create_user_preference"), eq(userId.toString()), any(CreateUserPreferenceEvent.class));
+        verify(kafkaTemplate).send(eq("created-user-preference"), eq(userId.toString()), any(CreateUserPreferenceEvent.class));
     }
 
     @Test
@@ -120,6 +132,7 @@ class CreateUserPreferenceUseCaseTest {
         when(user.getId()).thenReturn(userId);
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userPreferenceRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        stubKafkaSendSuccess();
 
         createUserPreferenceUseCase.execute(command);
 
@@ -137,6 +150,7 @@ class CreateUserPreferenceUseCaseTest {
         when(user.getId()).thenReturn(userId);
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userPreferenceRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        stubKafkaSendSuccess();
 
         var inOrder = inOrder(userPreferenceRepository, kafkaTemplate);
 
@@ -144,5 +158,26 @@ class CreateUserPreferenceUseCaseTest {
 
         inOrder.verify(userPreferenceRepository).save(any());
         inOrder.verify(kafkaTemplate).send(any(), any(), any());
+    }
+
+    @Test
+    void execute_shouldCountSuccessfulKafkaPublication() {
+        when(user.getId()).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userPreferenceRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        stubKafkaSendSuccess();
+
+        createUserPreferenceUseCase.execute(command);
+
+        assertThat(meterRegistry.get("vellumhub.kafka.events.published")
+                .tag("topic", "created-user-preference")
+                .tag("event_type", "CreateUserPreferenceEvent")
+                .counter()
+                .count()).isEqualTo(1.0);
+    }
+
+    private void stubKafkaSendSuccess() {
+        when(kafkaTemplate.send(any(), any(), any(CreateUserPreferenceEvent.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
     }
 }


### PR DESCRIPTION
This pull request introduces instrumentation for custom business and Kafka metrics in the `catalog-service`, ensuring that key domain actions (such as creating, updating, and deleting books, as well as updating reading progress) are now tracked and exported via Prometheus/Micrometer. It also updates documentation to clarify the new metrics, their Prometheus naming conventions, and how to validate them locally. Additionally, it improves test configuration in the Maven build process.

**Instrumentation and Metrics Integration:**

* Injected and utilized the `VellumHubMetrics` component in domain handlers (`CreateBookHandler`, `UpdateBookHandler`, `DeleteBookHandler`, and `UpdateBookProgressUseCase`) to record business counters for book creation, update, deletion, and reading progress updates. This ensures that all major domain events are now instrumented for metrics collection. [[1]](diffhunk://#diff-8c3b300eb9cb172b616cd300c311758a561f1e00463bf799cdf81ea3495b509eR12) [[2]](diffhunk://#diff-8c3b300eb9cb172b616cd300c311758a561f1e00463bf799cdf81ea3495b509eR25-R35) [[3]](diffhunk://#diff-8c3b300eb9cb172b616cd300c311758a561f1e00463bf799cdf81ea3495b509eR61) [[4]](diffhunk://#diff-245fd97c426c1e6484ce58cf5c8ec97c0cf1f27075f060a665490cbb51ff7781R13) [[5]](diffhunk://#diff-245fd97c426c1e6484ce58cf5c8ec97c0cf1f27075f060a665490cbb51ff7781R27-R37) [[6]](diffhunk://#diff-245fd97c426c1e6484ce58cf5c8ec97c0cf1f27075f060a665490cbb51ff7781R79) [[7]](diffhunk://#diff-cd20fe72b4978aff6bec5354eb008117c12c18fd41d60c50dd7b39c08b0db05dR7) [[8]](diffhunk://#diff-cd20fe72b4978aff6bec5354eb008117c12c18fd41d60c50dd7b39c08b0db05dR18-R23) [[9]](diffhunk://#diff-cd20fe72b4978aff6bec5354eb008117c12c18fd41d60c50dd7b39c08b0db05dR35) [[10]](diffhunk://#diff-354bb30132a51ef6701e768689283dd2d1e609679d1f2008f1027fea8c5817b4R10-R21) [[11]](diffhunk://#diff-354bb30132a51ef6701e768689283dd2d1e609679d1f2008f1027fea8c5817b4R37)
* Enhanced Kafka event producers (`KafkaBookEventProducer` and `KafkaBookProgressEventProducer`) to record metrics for successful and failed Kafka publishes, improving observability of message flow and failure scenarios. [[1]](diffhunk://#diff-3a0d186604acc50c7fc7e74055e325084f55d9c8e9dfd91e0cf307771391f6f4R4-L8) [[2]](diffhunk://#diff-3a0d186604acc50c7fc7e74055e325084f55d9c8e9dfd91e0cf307771391f6f4R18-R22) [[3]](diffhunk://#diff-3a0d186604acc50c7fc7e74055e325084f55d9c8e9dfd91e0cf307771391f6f4R33-R41) [[4]](diffhunk://#diff-2529432608d3602e5ef52c75f0a21fd3a955610da7f90aecb8709aea50077711R4) [[5]](diffhunk://#diff-2529432608d3602e5ef52c75f0a21fd3a955610da7f90aecb8709aea50077711R18-R22) [[6]](diffhunk://#diff-2529432608d3602e5ef52c75f0a21fd3a955610da7f90aecb8709aea50077711R33-R41)

**Documentation Updates:**

* Expanded `OBSERVABILITY.md` with a comprehensive list of new custom Kafka and business metrics, their Prometheus names, label conventions, and sample queries for local validation. Clarified that these metrics remain zero or empty until local traffic is generated. [[1]](diffhunk://#diff-3806ad73c39cafe7bbc7c33ba476d076c9eca7dd920b004c13dc14c003f4a004L55-R55) [[2]](diffhunk://#diff-3806ad73c39cafe7bbc7c33ba476d076c9eca7dd920b004c13dc14c003f4a004R82-R123) [[3]](diffhunk://#diff-3806ad73c39cafe7bbc7c33ba476d076c9eca7dd920b004c13dc14c003f4a004L107-R149) [[4]](diffhunk://#diff-3806ad73c39cafe7bbc7c33ba476d076c9eca7dd920b004c13dc14c003f4a004L210-R252)
* Updated runbooks to reflect the new metrics, including troubleshooting steps when business metrics are missing (e.g., due to lack of local traffic).

**Build and Configuration Improvements:**

* Updated the `pom.xml` for `catalog-service` to explicitly configure test compilation sources, ensuring correct test builds.

**Miscellaneous:**

* Minor import adjustment in `InitialGenreSeeder` to use Spring's `@Autowired` annotation.