### PR TITLE
#205 feat: add Testcontainers support and document runtime migration verification

### DIFF
--- a/docs/DATABASE_MIGRATIONS.md
+++ b/docs/DATABASE_MIGRATIONS.md
@@ -24,3 +24,27 @@ Keep migrations append-only after they are shared. For schema changes, update th
 ## Docker Compose
 
 The PostgreSQL `init.sql` files no longer create application schema. Compose creates the empty databases, then each service applies its own migrations during startup. The recommendation database still uses the pgvector image, and the `vector` extension is created by the recommendation migration.
+
+## Runtime verification
+
+Each database-owning service has a Testcontainers integration test that starts an empty PostgreSQL database with the `prod` profile. The test verifies that Flyway applies the schema, Hibernate validates it, and an incompatible schema prevents a second application startup. The recommendation test uses `pgvector/pgvector:pg15` and also verifies the `vector` extension and HNSW indexes.
+
+The services consume the local `kafka-contracts` artifact, so install it before running service tests independently:
+
+```powershell
+.\services\catalog-service\mvnw.cmd -f .\lib\kafka-contracts\pom.xml install
+
+foreach ($service in 'catalog-service','user-service','engagement-service','recommendation-service') {
+    Push-Location "services\$service"
+    .\mvnw.cmd test
+    Pop-Location
+}
+```
+
+Docker must be available to run the Testcontainers tests. To validate the same behavior through Compose without reusing existing volumes, run the stack with an isolated project name and inspect the four service healthchecks:
+
+```powershell
+docker compose -p vellumhub-migrations-test up -d --build
+docker compose -p vellumhub-migrations-test ps
+docker compose -p vellumhub-migrations-test down -v
+```

--- a/services/catalog-service/pom.xml
+++ b/services/catalog-service/pom.xml
@@ -28,6 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<testcontainers.version>1.20.4</testcontainers.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -103,6 +104,18 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>${testcontainers.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/services/catalog-service/src/test/java/com/vellumhub/catalog_service/share/config/FlywayPostgresIntegrationTest.java
+++ b/services/catalog-service/src/test/java/com/vellumhub/catalog_service/share/config/FlywayPostgresIntegrationTest.java
@@ -1,0 +1,89 @@
+package com.vellumhub.catalog_service.share.config;
+
+import com.vellumhub.catalog_service.CatalogServiceApplication;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@ActiveProfiles("prod")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class FlywayPostgresIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("catalog_migration_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configure(DynamicPropertyRegistry registry) {
+        runtimeProperties().forEach((name, value) -> registry.add(name, () -> value));
+    }
+
+    @Test
+    @Order(1)
+    void startsAgainstAnEmptyPostgresDatabaseAndAppliesTheInitialMigration(JdbcTemplate jdbcTemplate) {
+        assertThat(jdbcTemplate.queryForObject("select count(*) from flyway_schema_history where version = '1' and success", Integer.class)).isEqualTo(1);
+        assertThat(tableExists(jdbcTemplate, "genres")).isTrue();
+        assertThat(tableExists(jdbcTemplate, "books")).isTrue();
+        assertThat(tableExists(jdbcTemplate, "book_progress")).isTrue();
+        assertThat(indexExists(jdbcTemplate, "idx_book_progress_user_id")).isTrue();
+    }
+
+    @Test
+    @Order(2)
+    void refusesToStartWhenTheMigratedSchemaBecomesIncompatible(JdbcTemplate jdbcTemplate) {
+        jdbcTemplate.execute("alter table books drop column title");
+
+        assertThatThrownBy(() -> startApplication())
+                .hasStackTraceContaining("Schema-validation");
+    }
+
+    private static ConfigurableApplicationContext startApplication() {
+        return new SpringApplicationBuilder(CatalogServiceApplication.class)
+                .profiles("prod")
+                .web(WebApplicationType.NONE)
+                .properties(runtimeProperties())
+                .run();
+    }
+
+    private static Map<String, Object> runtimeProperties() {
+        return Map.of(
+                "spring.datasource.url", POSTGRES.getJdbcUrl(),
+                "spring.datasource.username", POSTGRES.getUsername(),
+                "spring.datasource.password", POSTGRES.getPassword(),
+                "spring.kafka.bootstrap-servers", "localhost:65535",
+                "spring.kafka.listener.auto-startup", "false",
+                "spring.kafka.admin.fail-fast", "false",
+                "management.health.kafka.enabled", "false",
+                "jwt.secret", "test-secret-test-secret-test-secret-test-secret",
+                "server.port", "0");
+    }
+
+    private boolean tableExists(JdbcTemplate jdbcTemplate, String table) {
+        return Boolean.TRUE.equals(jdbcTemplate.queryForObject("select exists (select 1 from information_schema.tables where table_schema = 'public' and table_name = ?)", Boolean.class, table));
+    }
+
+    private boolean indexExists(JdbcTemplate jdbcTemplate, String index) {
+        return Boolean.TRUE.equals(jdbcTemplate.queryForObject("select exists (select 1 from pg_indexes where schemaname = 'public' and indexname = ?)", Boolean.class, index));
+    }
+}

--- a/services/engagement-service/pom.xml
+++ b/services/engagement-service/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <java.version>21</java.version>
+        <testcontainers.version>1.20.4</testcontainers.version>
     </properties>
 
     <dependencies>
@@ -98,6 +99,18 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/services/engagement-service/src/test/java/com/vellumhub/engagement_service/share/config/FlywayPostgresIntegrationTest.java
+++ b/services/engagement-service/src/test/java/com/vellumhub/engagement_service/share/config/FlywayPostgresIntegrationTest.java
@@ -1,0 +1,90 @@
+package com.vellumhub.engagement_service.share.config;
+
+import com.vellumhub.engagement_service.EngagementServiceApplication;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@ActiveProfiles("prod")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class FlywayPostgresIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("engagement_migration_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configure(DynamicPropertyRegistry registry) {
+        runtimeProperties().forEach((name, value) -> registry.add(name, () -> value));
+    }
+
+    @Test
+    @Order(1)
+    void startsAgainstAnEmptyPostgresDatabaseAndAppliesAllMigrations(JdbcTemplate jdbcTemplate) {
+        assertThat(jdbcTemplate.queryForObject("select count(*) from flyway_schema_history where version in ('1', '2') and success", Integer.class)).isEqualTo(2);
+        assertThat(tableExists(jdbcTemplate, "book_snapshot")).isTrue();
+        assertThat(tableExists(jdbcTemplate, "rating")).isTrue();
+        assertThat(tableExists(jdbcTemplate, "reactions")).isTrue();
+        assertThat(tableExists(jdbcTemplate, "reading_session_entries")).isTrue();
+        assertThat(indexExists(jdbcTemplate, "idx_rating_user_id")).isTrue();
+    }
+
+    @Test
+    @Order(2)
+    void refusesToStartWhenTheMigratedSchemaBecomesIncompatible(JdbcTemplate jdbcTemplate) {
+        jdbcTemplate.execute("alter table rating drop column stars");
+
+        assertThatThrownBy(() -> startApplication())
+                .hasStackTraceContaining("Schema-validation");
+    }
+
+    private static ConfigurableApplicationContext startApplication() {
+        return new SpringApplicationBuilder(EngagementServiceApplication.class)
+                .profiles("prod")
+                .web(WebApplicationType.NONE)
+                .properties(runtimeProperties())
+                .run();
+    }
+
+    private static Map<String, Object> runtimeProperties() {
+        return Map.of(
+                "spring.datasource.url", POSTGRES.getJdbcUrl(),
+                "spring.datasource.username", POSTGRES.getUsername(),
+                "spring.datasource.password", POSTGRES.getPassword(),
+                "spring.kafka.bootstrap-servers", "localhost:65535",
+                "spring.kafka.listener.auto-startup", "false",
+                "spring.kafka.admin.fail-fast", "false",
+                "management.health.kafka.enabled", "false",
+                "jwt.secret", "test-secret-test-secret-test-secret-test-secret",
+                "server.port", "0");
+    }
+
+    private boolean tableExists(JdbcTemplate jdbcTemplate, String table) {
+        return Boolean.TRUE.equals(jdbcTemplate.queryForObject("select exists (select 1 from information_schema.tables where table_schema = 'public' and table_name = ?)", Boolean.class, table));
+    }
+
+    private boolean indexExists(JdbcTemplate jdbcTemplate, String index) {
+        return Boolean.TRUE.equals(jdbcTemplate.queryForObject("select exists (select 1 from pg_indexes where schemaname = 'public' and indexname = ?)", Boolean.class, index));
+    }
+}

--- a/services/recommendation-service/pom.xml
+++ b/services/recommendation-service/pom.xml
@@ -19,6 +19,7 @@
     <properties>
         <java.version>21</java.version>
         <spring-cloud.version>2025.1.1</spring-cloud.version>
+        <testcontainers.version>1.20.4</testcontainers.version>
     </properties>
 
     <dependencies>
@@ -105,6 +106,18 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/config/FlywayPostgresIntegrationTest.java
+++ b/services/recommendation-service/src/test/java/com/vellumhub/recommendation_service/share/config/FlywayPostgresIntegrationTest.java
@@ -1,0 +1,92 @@
+package com.vellumhub.recommendation_service.share.config;
+
+import com.vellumhub.recommendation_service.RecommendationServiceApplication;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@ActiveProfiles("prod")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class FlywayPostgresIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(DockerImageName.parse("pgvector/pgvector:pg15").asCompatibleSubstituteFor("postgres"))
+            .withDatabaseName("recommendation_migration_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configure(DynamicPropertyRegistry registry) {
+        runtimeProperties().forEach((name, value) -> registry.add(name, () -> value));
+    }
+
+    @Test
+    @Order(1)
+    void startsAgainstAnEmptyPgvectorDatabaseAndAppliesTheInitialMigration(JdbcTemplate jdbcTemplate) {
+        assertThat(jdbcTemplate.queryForObject("select count(*) from flyway_schema_history where version = '1' and success", Integer.class)).isEqualTo(1);
+        assertThat(tableExists(jdbcTemplate, "book_features")).isTrue();
+        assertThat(tableExists(jdbcTemplate, "user_profiles")).isTrue();
+        assertThat(tableExists(jdbcTemplate, "recommendations")).isTrue();
+        assertThat(jdbcTemplate.queryForObject("select count(*) from pg_extension where extname = 'vector'", Integer.class)).isEqualTo(1);
+        assertThat(indexExists(jdbcTemplate, "idx_book_features_embedding_hnsw")).isTrue();
+        assertThat(indexExists(jdbcTemplate, "idx_user_profiles_profile_vector_hnsw")).isTrue();
+    }
+
+    @Test
+    @Order(2)
+    void refusesToStartWhenTheMigratedSchemaBecomesIncompatible(JdbcTemplate jdbcTemplate) {
+        jdbcTemplate.execute("alter table recommendations drop column title");
+
+        assertThatThrownBy(() -> startApplication())
+                .hasStackTraceContaining("Schema-validation");
+    }
+
+    private static ConfigurableApplicationContext startApplication() {
+        return new SpringApplicationBuilder(RecommendationServiceApplication.class)
+                .profiles("prod")
+                .web(WebApplicationType.NONE)
+                .properties(runtimeProperties())
+                .run();
+    }
+
+    private static Map<String, Object> runtimeProperties() {
+        return Map.of(
+                "spring.datasource.url", POSTGRES.getJdbcUrl(),
+                "spring.datasource.username", POSTGRES.getUsername(),
+                "spring.datasource.password", POSTGRES.getPassword(),
+                "spring.kafka.bootstrap-servers", "localhost:65535",
+                "spring.kafka.listener.auto-startup", "false",
+                "spring.kafka.admin.fail-fast", "false",
+                "management.health.kafka.enabled", "false",
+                "jwt.secret", "test-secret-test-secret-test-secret-test-secret",
+                "server.port", "0");
+    }
+
+    private boolean tableExists(JdbcTemplate jdbcTemplate, String table) {
+        return Boolean.TRUE.equals(jdbcTemplate.queryForObject("select exists (select 1 from information_schema.tables where table_schema = 'public' and table_name = ?)", Boolean.class, table));
+    }
+
+    private boolean indexExists(JdbcTemplate jdbcTemplate, String index) {
+        return Boolean.TRUE.equals(jdbcTemplate.queryForObject("select exists (select 1 from pg_indexes where schemaname = 'public' and indexname = ?)", Boolean.class, index));
+    }
+}

--- a/services/user-service/pom.xml
+++ b/services/user-service/pom.xml
@@ -15,6 +15,7 @@
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>21</java.version>
+		<testcontainers.version>1.20.4</testcontainers.version>
 	</properties>
 
 	<dependencies>
@@ -109,6 +110,18 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>${testcontainers.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/services/user-service/src/test/java/com/vellumhub/user_service/share/config/FlywayPostgresIntegrationTest.java
+++ b/services/user-service/src/test/java/com/vellumhub/user_service/share/config/FlywayPostgresIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.vellumhub.user_service.share.config;
+
+import com.vellumhub.user_service.UserServiceApplication;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@ActiveProfiles("prod")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class FlywayPostgresIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("user_migration_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configure(DynamicPropertyRegistry registry) {
+        runtimeProperties().forEach((name, value) -> registry.add(name, () -> value));
+    }
+
+    @Test
+    @Order(1)
+    void startsAgainstAnEmptyPostgresDatabaseAndAppliesTheInitialMigration(JdbcTemplate jdbcTemplate) {
+        assertThat(jdbcTemplate.queryForObject("select count(*) from flyway_schema_history where version = '1' and success", Integer.class)).isEqualTo(1);
+        assertThat(tableExists(jdbcTemplate, "tb_users")).isTrue();
+        assertThat(tableExists(jdbcTemplate, "user_preferences")).isTrue();
+        assertThat(tableExists(jdbcTemplate, "user_preference_genres")).isTrue();
+        assertThat(indexExists(jdbcTemplate, "uk_tb_users_email")).isTrue();
+    }
+
+    @Test
+    @Order(2)
+    void refusesToStartWhenTheMigratedSchemaBecomesIncompatible(JdbcTemplate jdbcTemplate) {
+        jdbcTemplate.execute("alter table tb_users drop column email");
+
+        assertThatThrownBy(() -> startApplication())
+                .hasStackTraceContaining("Schema-validation");
+    }
+
+    private static ConfigurableApplicationContext startApplication() {
+        return new SpringApplicationBuilder(UserServiceApplication.class)
+                .profiles("prod")
+                .web(WebApplicationType.NONE)
+                .properties(runtimeProperties())
+                .run();
+    }
+
+    private static Map<String, Object> runtimeProperties() {
+        return Map.of(
+                "spring.datasource.url", POSTGRES.getJdbcUrl(),
+                "spring.datasource.username", POSTGRES.getUsername(),
+                "spring.datasource.password", POSTGRES.getPassword(),
+                "spring.kafka.bootstrap-servers", "localhost:65535",
+                "spring.kafka.listener.auto-startup", "false",
+                "spring.kafka.admin.fail-fast", "false",
+                "management.health.kafka.enabled", "false",
+                "jwt.secret", "dGVzdC1zZWNyZXQta2V5LWZvci10ZXN0aW5nLXB1cnBvc2VzLXdpdGgtYXQtbGVhc3QtMjU2LWJpdHM=",
+                "jwt.expiration-ms", "3600000",
+                "google.client.id", "test-client-id",
+                "server.port", "0");
+    }
+
+    private boolean tableExists(JdbcTemplate jdbcTemplate, String table) {
+        return Boolean.TRUE.equals(jdbcTemplate.queryForObject("select exists (select 1 from information_schema.tables where table_schema = 'public' and table_name = ?)", Boolean.class, table));
+    }
+
+    private boolean indexExists(JdbcTemplate jdbcTemplate, String index) {
+        return Boolean.TRUE.equals(jdbcTemplate.queryForObject("select exists (select 1 from pg_indexes where schemaname = 'public' and indexname = ?)", Boolean.class, index));
+    }
+}


### PR DESCRIPTION
This pull request introduces comprehensive runtime integration tests for database migrations across all services, ensuring that Flyway migrations are correctly applied and that schema validation will fail on incompatible changes. It adds Testcontainers-based integration tests to each service, updates Maven dependencies to include Testcontainers, and documents the new verification approach. This significantly improves confidence in schema changes and migration safety.

**Runtime migration verification and integration tests:**

* Added Testcontainers-based integration tests (`FlywayPostgresIntegrationTest`) for each service (`catalog-service`, `engagement-service`, `recommendation-service`, `user-service`) to verify that:
  * The application starts and applies all Flyway migrations to a clean PostgreSQL database.
  * The application fails to start if the schema is made incompatible after migration (by dropping a required column). [[1]](diffhunk://#diff-4b81a9a3b3c58f840508be083063e13c4f6bafd5561aca724c7568a4a4867863R1-R89) [[2]](diffhunk://#diff-3d55b717214065c71f205ec4f8efdf6e314a48c229fed39f9051e38aa46ac758R1-R90) [[3]](diffhunk://#diff-2b3dad23ba32495f072f2175192d0401fa142d2ba353e656c05fb45c692d2925R1-R92) [[4]](diffhunk://#diff-6f25c61fd19534f7115895a595c5265dc66665791a454276c679f35a4bf9bac7R1-R91)

* The recommendation service test uses the `pgvector/pgvector:pg15` image and additionally verifies the presence of the `vector` extension and HNSW indexes.

**Dependency and configuration updates:**

* Updated Maven `pom.xml` files for all services to add `testcontainers-junit-jupiter` and `testcontainers-postgresql` as test dependencies, and defined a shared `testcontainers.version` property. [[1]](diffhunk://#diff-1cad9bc3181f39da755d88d5251867b69242475e7fc8ac61b78c7ee5928a973bR31) [[2]](diffhunk://#diff-1cad9bc3181f39da755d88d5251867b69242475e7fc8ac61b78c7ee5928a973bR109-R120) [[3]](diffhunk://#diff-406865c6502c0bd64043b365f9d8c5bb50c0566fb9ee125a96620687151e101bR20) [[4]](diffhunk://#diff-406865c6502c0bd64043b365f9d8c5bb50c0566fb9ee125a96620687151e101bR104-R115) [[5]](diffhunk://#diff-942f5d5d899a3309008fc292518d8d182de8ef1c14f9438e6b4e15f12d32047eR22) [[6]](diffhunk://#diff-942f5d5d899a3309008fc292518d8d182de8ef1c14f9438e6b4e15f12d32047eR111-R122) [[7]](diffhunk://#diff-3539f0d1650fb51f90517b9940e1312a1c56229b2369656b32cdc003f8036b13R18) [[8]](diffhunk://#diff-3539f0d1650fb51f90517b9940e1312a1c56229b2369656b32cdc003f8036b13R115-R126)

**Documentation:**

* Updated `docs/DATABASE_MIGRATIONS.md` to describe the new runtime verification process, including instructions for running the integration tests and verifying migrations using Docker Compose.