### PR TITLE
Rewrite README around verified recommendation-system evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,410 +1,203 @@
 # VellumHub
 
-> A production-grade JVM microservices backend for book discovery — demonstrating distributed system design through service-owned databases, event-carried state transfer, vector-based recommendations, gateway-enforced security, and operational hardening.
+> A production-oriented Java reference system for event-driven recommendation, built around service-owned data, Kafka-fed read models, and observable failure paths.
 
 [![Java](https://img.shields.io/badge/Java-21-orange)](https://openjdk.org/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.4.x%20%2F%204.0.x-green)](https://spring.io/projects/spring-boot)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.4%20%2F%204.0-green)](https://spring.io/projects/spring-boot)
 [![Kafka](https://img.shields.io/badge/Kafka-event--driven-black)](https://kafka.apache.org/)
 [![pgvector](https://img.shields.io/badge/pgvector-HNSW%20cosine-blue)](https://github.com/pgvector/pgvector)
-[![Spring Cloud Gateway](https://img.shields.io/badge/Spring%20Cloud-Gateway-blue)](https://spring.io/projects/spring-cloud-gateway)
-[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15-blue)](https://www.postgresql.org/)
-[![Redis](https://img.shields.io/badge/Redis-rate%20limit-red)](https://redis.io/)
-[![Docker](https://img.shields.io/badge/Docker-Compose-blue)](https://www.docker.com/)
+[![Tests](https://img.shields.io/badge/tests-478%20passing-brightgreen)](#verification)
 
-VellumHub is the backend infrastructure of a social reading platform. Users discover books, track reading progress, rate titles, react to content, and receive personalized recommendations — served by five independent services communicating through Kafka events.
+VellumHub is the backend of a social reading and recommendation platform. Its main engineering constraint is explicit: recommendation serving must not depend on request-time calls to catalog, user, or engagement services.
 
-The project is written as a backend engineering reference system. The goal is not merely to expose CRUD endpoints, but to show how identity, catalog ownership, reader engagement, asynchronous replication, vector ranking, gateway security, observability, and reliability hardening fit together in one coherent platform.
+The project demonstrates how service-owned databases, Event-Carried State Transfer, vector ranking, gateway security, retry/DLT behavior, and observability fit together in one coherent JVM system.
 
-The current architecture is a mature v3 platform moving through v4 reliability hardening. The five-service topology, Kafka backbone, gateway JWT enforcement, service-owned databases, and pgvector recommendation model are in place. The active focus is correctness and operational resilience: topic contracts, idempotent consumers, transactional outbox, database migrations, production security, tracing, and integration testing.
+## Evidence at a glance
 
----
-
-## Contents
-
-- [System at a Glance](#system-at-a-glance)
-- [Architecture](#architecture)
-- [Repository Layout](#repository-layout)
-- [Service Map](#service-map)
-- [Core Flows](#core-flows)
-- [Recommendation Engine](#recommendation-engine)
-- [Kafka Event Contracts](#kafka-event-contracts)
-- [Kafka Resilience](#kafka-resilience)
-- [Gateway and Security](#gateway-and-security)
-- [Running Locally](#running-locally)
-- [Observability](#observability)
-- [Quality and Test Coverage](#quality-and-test-coverage)
-- [Roadmap](#roadmap)
-- [Design Decisions](#design-decisions)
-- [References](#references)
-
----
-
-## System at a Glance
-
-### Scale
-
-| Dimension | Value |
+| Signal | Current evidence |
 |---|---:|
 | Application services | 5 |
-| Docker Compose services, default profile | 13 |
-| Optional observability services | 5 |
-| Main Java files | 393 |
-| Test Java files | 92 |
-| Controllers | 15 |
-| Use case classes | 44 |
-| Kafka listener classes | 14 |
-
-### Recommendation model
-
-| Dimension | Value |
-|---|---|
+| Recommendation hot-path upstream calls | 0 |
+| Latest consolidated Maven validation | 478 tests passing |
+| Local benchmark before | ~300-500 ms with Python sidecar |
+| Local benchmark after | ~80-120 ms in-process JVM + pgvector |
 | Embedding dimensions | 384 |
-| Index type | HNSW cosine |
-| ANN candidate pool | 200 books |
-| Ranking blend | 70% semantic / 30% popularity |
-| Local benchmark latency | ~80-120 ms in-JVM pgvector |
-| Previous architecture latency | ~300-500 ms with external Python ML sidecar |
+| ANN index | HNSW cosine |
 
-The latency numbers are project-local benchmark notes, not production SLAs.
+The latency figures are local project benchmarks, not production SLAs.
 
-### Local quality evidence
+## Problem, decision, result
 
-| Area | Current evidence |
-|---|---|
-| Gateway tests | Recorded passing local run |
-| Catalog tests | Recorded passing local run |
-| Gateway suite | 1 test, 0 failures, 0 errors |
-| Catalog suite | 142 tests, 0 failures, 0 errors |
-| Latest recorded passing run | 2026-05-25 |
+### Problem
 
-Coverage percentage is not claimed because no local JaCoCo configuration or generated coverage report was found during inspection.
+A recommendation request that synchronously queries catalog, user, and engagement services inherits the latency and availability of every dependency. The earlier architecture also used a separate Python ML sidecar, adding another network and runtime boundary.
 
----
+### Decision
+
+Upstream domain changes are propagated through Kafka and materialized into recommendation-owned tables. The recommendation service owns its serving state and generates embeddings in-process on the JVM.
+
+### Result
+
+- Recommendation requests read from local PostgreSQL/pgvector state only.
+- Catalog, preference, rating, reaction, and progress changes arrive asynchronously.
+- The Python sidecar was removed from the serving path.
+- Local benchmark latency moved from roughly 300-500 ms to 80-120 ms.
+- The latest consolidated validation records 478 Maven tests passing across the platform.
 
 ## Architecture
 
-All public HTTP traffic enters through the gateway. Downstream services also validate JWTs independently, so the gateway is an ingress boundary rather than the only security boundary.
-
 ```mermaid
-graph TB
-    Client[Client] --> Gateway[Gateway Service\nSpring Cloud Gateway + WebFlux]
-    Gateway --> Redis[(Redis\nrate-limit state)]
-
+flowchart TB
+    Client[Client] --> Gateway[Gateway Service]
+    Gateway --> Redis[(Redis rate-limit state)]
     Gateway --> User[User Service]
     Gateway --> Catalog[Catalog Service]
     Gateway --> Engagement[Engagement Service]
     Gateway --> Recommendation[Recommendation Service]
 
-    User --> UserDb[(user_db\nPostgreSQL)]
-    Catalog --> CatalogDb[(catalog_db\nPostgreSQL)]
-    Engagement --> EngagementDb[(engagement_db\nPostgreSQL)]
-    Recommendation --> RecommendationDb[(recommendation_db\nPostgreSQL + pgvector)]
+    User --> UserDb[(user_db)]
+    Catalog --> CatalogDb[(catalog_db)]
+    Engagement --> EngagementDb[(engagement_db)]
+    Recommendation --> RecommendationDb[(recommendation_db + pgvector)]
 
-    User -->|preferences| Kafka[(Kafka Event Backbone\n\nbook lifecycle topics\nreading progress topics\nrating/reaction topics\nuser preference topics)]
-    Catalog -->|book + progress events| Kafka
-    Engagement -->|rating + reaction events| Kafka
+    User -->|preferences| Kafka[(Kafka)]
+    Catalog -->|book and progress events| Kafka
+    Engagement -->|rating and reaction events| Kafka
 
-    Kafka -->|book snapshots| Engagement
-    Kafka -->|features + profile learning| Recommendation
-    Kafka -->|exhausted retries| Dlt[Dead Letter Topics\n*-dlt]
+    Kafka -->|local projections| Engagement
+    Kafka -->|features and profile learning| Recommendation
+    Kafka -->|exhausted retries| DLT[Dead Letter Topics]
 
-    style Kafka fill:#111827,color:#ffffff,stroke:#f59e0b,stroke-width:4px,font-size:18px
+    Recommendation -->|query local state| RecommendationDb
 ```
 
-Key architectural choices:
+### Ownership boundaries
 
-- **Service-owned databases:** each service owns its domain model and schema. There are no shared application tables.
-- **Event-carried state transfer:** downstream services build local read models from Kafka events instead of querying source services in critical paths.
-- **Local recommendation serving:** the recommendation service reads from its own `book_features`, `user_profiles`, and `recommendations` tables at query time, with no synchronous calls to catalog, engagement, or user services.
-- **Gateway-controlled ingress:** Spring Cloud Gateway WebFlux enforces JWT authentication and Redis-backed rate limits before requests reach downstream services.
-- **Defense in depth:** downstream services validate JWTs independently instead of relying exclusively on the gateway.
-- **Operational visibility:** the local platform includes Actuator, Prometheus metrics, structured logs, OpenTelemetry Java Agent traces, Kafka UI, and an optional Grafana/Prometheus/Loki/Tempo/Alloy stack.
+| Service | Source of truth |
+|---|---|
+| `user-service` | identity, authentication, users, preference seeds |
+| `catalog-service` | books, lists, memberships, current reading progress |
+| `engagement-service` | ratings, reactions, replicated progress history |
+| `recommendation-service` | book features, profile vectors, recommendation projections |
+| `gateway-service` | public routing, JWT enforcement, route rate limits |
 
-Existing Feign-related configuration in `recommendation-service` is legacy cleanup debt, not an active recommendation query-time dependency.
+Each service owns its application schema. There are no shared application tables.
 
----
+## Core flows
 
-## Repository Layout
+### Registration to cold start
 
-```text
-.
-├── services/           # Application service modules
-│   ├── gateway-service
-│   ├── user-service
-│   ├── catalog-service
-│   ├── engagement-service
-│   └── recommendation-service
-├── infra/              # Docker, observability config, scripts
-├── docs/               # Architecture and operational documentation
-├── docker-compose.yml
-└── .env.example
-```
+1. A user registers with genre preferences.
+2. `user-service` persists the account and publishes a preference event.
+3. `recommendation-service` creates an initial profile vector before the user has interactions.
 
-Application code lives under `services/`. Local environment definitions, Docker support files, observability configuration, and operational scripts live under `infra/`. Project documentation lives under `docs/`, while root-level files are kept for common entrypoints such as `docker-compose.yml`, `.env.example`, and this README.
+### Catalog change to local projection
 
----
+1. `catalog-service` changes book state.
+2. A lifecycle event is published to Kafka.
+3. Recommendation and engagement consumers update their own projections.
+4. Future queries do not need to call catalog synchronously.
 
-## Service Map
+### Engagement to profile learning
 
-| Service | Responsibility | Details |
-|---|---|---|
-| `gateway-service` | Public edge for routing, JWT enforcement, and Redis-backed rate limiting | [README](services/gateway-service/README.md) |
-| `user-service` | Identity, authentication, Google login, user management, and preference seeds for cold-start recommendations | [README](services/user-service/README.md) |
-| `catalog-service` | Source of truth for books, book requests, book lists, membership, covers, and current reading progress | [README](services/catalog-service/README.md) |
-| `engagement-service` | Ratings, reactions, replicated reading progress history, and book snapshots | [README](services/engagement-service/README.md) |
-| `recommendation-service` | Event-fed read model, embeddings, user profile vectors, and ranking | [README](services/recommendation-service/README.md) |
+1. A rating, reaction, or reading-progress event is published.
+2. `recommendation-service` updates the user's profile vector.
+3. Already-interacted books are excluded during ranking.
 
-The root README stays focused on system shape, reliability posture, and local operation. Endpoint-level inventories and OpenAPI details live in each service README and service-local Swagger UI.
+### Recommendation serving
 
----
+1. The gateway validates the request and applies rate limiting.
+2. `recommendation-service` loads the user profile and candidates from local PostgreSQL/pgvector tables.
+3. Candidates are ranked and returned without synchronous upstream calls.
 
-## Core Flows
+## Recommendation model
 
-### 1. Registration to cold-start profile
-
-A user registers with genre preferences. `user-service` publishes `created-user-preference`, and `recommendation-service` seeds a profile vector before the user has ratings or reactions.
-
-### 2. Catalog mutation to local projections
-
-`catalog-service` owns book state and emits lifecycle events. Recommendation and engagement consume those events to update local read models without joining through shared databases or performing synchronous source-service reads.
-
-### 3. Reader engagement to learning signal
-
-Ratings, reactions, and reading progress become Kafka signals that adjust user profile vectors inside the recommendation service.
-
-### 4. Recommendation serving
-
-The gateway routes authenticated recommendation traffic to `recommendation-service`, which ranks from local PostgreSQL + pgvector tables without synchronous calls to catalog, engagement, or user services.
-
-### Representative asynchronous flow — rating feedback
-
-```mermaid
-sequenceDiagram
-    participant U as User
-    participant G as Gateway
-    participant E as Engagement Service
-    participant K as Kafka
-    participant R as Recommendation Service
-
-    U->>G: POST /api/v1/engagement/rating
-    G->>G: Validate JWT + apply route rate limit
-    G->>E: Forward request
-    E->>E: Persist rating
-    E->>K: Publish created-rating
-    K->>R: Deliver created-rating
-    R->>R: Update user_profile vector
-```
-
----
-
-## Recommendation Engine
-
-The recommendation service consumes catalog and interaction events and maintains local projection tables:
+The service maintains three main projection tables:
 
 | Table | Purpose |
 |---|---|
-| `book_features` | Book embedding and popularity state, stored as `vector(384)` |
-| `user_profiles` | Per-user preference vector, interacted book IDs, and engagement score |
-| `recommendations` | Denormalized book metadata for response assembly without source-service calls |
-
-The embedding pipeline uses LangChain4j's in-process `AllMiniLmL6V2EmbeddingModel`, which runs in the JVM and produces 384-dimensional vectors. Book and profile vectors are L2-normalized before cosine-distance ranking.
+| `book_features` | embedding and popularity state for each book |
+| `user_profiles` | preference vector and interaction history per user |
+| `recommendations` | denormalized response metadata |
 
 Ranking path:
 
-1. `book_features.embedding` is stored as `vector(384)`.
-2. `idx_book_embedding_hnsw` uses HNSW with `vector_cosine_ops`.
-3. ANN search retrieves a candidate pool of 200 books.
-4. Already-interacted books are filtered at query time.
-5. Candidates are re-ranked with a 70% semantic / 30% popularity blend.
-6. If a user profile is missing, the service falls back to popularity ranking.
+1. Generate 384-dimensional embeddings with the in-process `all-MiniLM-L6-v2` model.
+2. Store vectors in PostgreSQL using pgvector.
+3. Retrieve an ANN candidate pool through HNSW cosine search.
+4. Exclude already-interacted books.
+5. Blend semantic score and popularity.
+6. Fall back to popularity when a profile does not yet exist.
 
-Historical local benchmark notes describe the move from an external Python ML sidecar to in-JVM pgvector ranking as a latency improvement from roughly 300-500 ms to 80-120 ms. Treat these numbers as local project measurements, not a published production SLA.
+## Kafka contracts and resilience
 
----
+Kafka is used for state propagation, not as a substitute for ownership. Producers publish business events; consumers update local projections.
 
-## Kafka Event Contracts
+Representative topics cover:
 
-Kafka is the state propagation backbone. Producers publish business events; consumers maintain local projections from those events.
+- book creation, update, and deletion;
+- reading progress;
+- ratings and reactions;
+- user preference seeds.
 
-### Topic inventory
+Consumer behavior includes:
 
-Kafka topic names, type aliases, and cross-service event payloads are centralized in `lib/kafka-contracts`.
+- retry topics with fixed backoff;
+- bounded attempts;
+- Dead Letter Topics for exhausted messages;
+- DLT logs that expose topic and error metadata without printing raw payloads by default.
 
-| Topic | Producer | Consumer(s) |
-|---|---|---|
-| `created-book` | Catalog | Recommendation, Engagement book snapshot |
-| `updated-book` | Catalog | Recommendation |
-| `deleted-book` | Catalog | Recommendation, Engagement book snapshot |
-| `created-rating` | Engagement | Recommendation user profile learning |
-| `user-reaction-changed` | Engagement | Recommendation user profile learning |
-| `created-user-preference` | User | Recommendation cold-start profile seed |
-| `created-reading-progress` | Catalog | Engagement reading history |
-| `updated-reading-progress` | Catalog | Recommendation user profile learning |
+Current hardening work includes stronger drift detection for topic contracts, consumer idempotency, transactional outbox delivery, and end-to-end Testcontainers verification.
 
-The contract library keeps producers, consumers, retry configuration, and JSON type mappings aligned to one source of truth.
+## Gateway and security
 
----
+Spring Cloud Gateway is the public ingress boundary.
 
-## Kafka Resilience
+- JWT validation at the gateway.
+- Independent JWT validation in downstream services.
+- Redis-backed route rate limits.
+- Principal-based keys with IP fallback where applicable.
+- Restricted Actuator exposure in production-oriented profiles.
 
-Recommendation and engagement consumers use Spring Kafka retry topic configuration:
+The gateway is not treated as the only security boundary.
 
-- Fixed 3-second backoff.
-- Maximum of 3 attempts.
-- Retry topic forwarding instead of local `try/catch` swallowing.
-- Centralized `*-dlt` listeners for exhausted messages.
+## Observability
 
-Dead Letter Topic logs include the original topic, DLT topic, exception message, and payload byte length. They do not print raw payloads by default, keeping the recovery signal useful without exposing Kafka message content in logs.
+The optional observability profile provides:
 
-The implemented system already uses Kafka for local projections and recommendation learning. The remaining work is to make topic contracts impossible to drift silently, then harden consumer idempotency and transactional event publication.
+- Prometheus metrics;
+- Grafana dashboards;
+- Loki structured logs;
+- Tempo traces;
+- Alloy collection and forwarding;
+- Kafka UI for topic and consumer inspection.
 
----
+The project records HTTP, JVM, database, Kafka, DLT, and recommendation signals. Labels are intentionally low-cardinality.
 
-## Gateway and Security
+Operational documentation:
 
-The gateway is built with Spring Cloud Gateway on WebFlux and Project Reactor. It routes public prefixes to internal services and applies request limiting through Redis.
+- [`docs/OBSERVABILITY.md`](docs/OBSERVABILITY.md)
+- [`docs/OBSERVABILITY_RUNBOOKS.md`](docs/OBSERVABILITY_RUNBOOKS.md)
+- [`docs/KAFKA_MONITORING.md`](docs/KAFKA_MONITORING.md)
 
-### Route table
+## Verification
 
-| Public prefix | Internal target |
-|---|---|
-| `/api/v1/auth/**` | `user-service` |
-| `/api/v1/users/**` | `user-service` |
-| `/api/v1/catalog/**` | `catalog-service` |
-| `/api/v1/engagement/**` | `engagement-service` |
-| `/api/v1/recommendations/**` | `recommendation-service` |
+Latest consolidated project record:
 
-### Rate limits
-
-| Route group | Replenish rate | Burst capacity | Key strategy |
-|---|---:|---:|---|
-| Auth / User | 5 req/s | 10 | IP |
-| Catalog / Engagement | 30 req/s | 60 | Principal → IP fallback |
-| Recommendations | 20 req/s | 40 | Principal → IP fallback |
-
-### Current hardening posture
-
-- The gateway is the public ingress boundary, but downstream services still validate JWTs independently.
-- Health endpoints remain reachable for Docker healthchecks.
-- Broader Actuator endpoints such as `info` and `metrics` require authentication on application services and gateway.
-- In the `prod` profile, health details are hidden and gateway logging is reduced from local `TRACE` diagnostics to `INFO`.
-- Remaining operational security work includes removing unsafe production defaults, tightening Actuator exposure, hardening secret handling, and reducing production log verbosity.
-
----
-
-## Running Locally
-
-### Prerequisites
-
-- Docker and Docker Compose
-- Java 21
-- A `.env` file based on [`.env.example`](.env.example)
-
-Required environment shape:
-
-```env
-POSTGRES_USER=your_user
-POSTGRES_PASSWORD=your_password
-JWT_KEY=base64_encoded_secret_at_least_32_bytes
-JWT_EXPIRATION_MS=604800000
-GOOGLE_CLIENT_ID=your_google_client_id
-CORS_ALLOWED_ORIGINS=http://localhost:3000
+```text
+478 Maven tests passing across the platform
 ```
 
-For the Docker Compose `prod` profile used by the local stack, `JWT_KEY` is required by all five application services. `JWT_EXPIRATION_MS` is also required by `user-service`, and `GOOGLE_CLIENT_ID` is required for Google login support.
+The strongest coverage is around domain behavior, use cases, controllers, Kafka consumers, mappers, and repository adapters. The next verification step is broader Testcontainers coverage for real Kafka/PostgreSQL projection, retry, DLT, idempotency, and outbox flows.
 
-Generate a local Base64 JWT key:
-
-```bash
-openssl rand -base64 32
-```
-
-Windows PowerShell alternative:
-
-```powershell
-$bytes = New-Object byte[] 32
-$rng = New-Object System.Security.Cryptography.RNGCryptoServiceProvider
-$rng.GetBytes($bytes)
-[Convert]::ToBase64String($bytes)
-$rng.Dispose()
-```
-
-### Start the default stack
-
-```bash
-docker-compose up -d
-```
-
-The default Compose stack defines 13 services:
-
-- `gateway-service`
-- `user-service`
-- `catalog-service`
-- `engagement-service`
-- `recommendation-service`
-- `postgres-user`
-- `postgres-catalog`
-- `postgres-engagement`
-- `postgres-recommendation`
-- `redis-gateway`
-- `zookeeper`
-- `kafka`
-- `kafka-ui`
-
-Published local endpoints:
-
-| Component | URL |
-|---|---|
-| API Gateway | `http://localhost:8080` |
-| Kafka UI | `http://localhost:8090` |
-
-Application services run inside the Docker network on port `8080`. Direct host access to downstream services is a development workflow, not the default Compose exposure.
-
-### Start with observability
-
-```bash
-docker compose --profile observability up -d --build
-```
-
-This adds Prometheus, Grafana, Loki, Tempo, and Alloy. Operational details live in [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
-
-### Run a service directly
-
-Each service has its own Maven wrapper:
+Run a service suite:
 
 ```bash
 cd services/catalog-service
-./mvnw spring-boot:run
+./mvnw test
 ```
 
-Windows PowerShell:
-
-```powershell
-cd services\catalog-service
-.\mvnw.cmd spring-boot:run
-```
-
-When running multiple services directly, set distinct `SERVER_PORT` values to avoid local port conflicts.
-
-### Verify the topology
-
-```bash
-docker compose config --services
-```
-
-### Run tests
-
-Recorded passing local suites:
-
-```powershell
-cd services\gateway-service
-.\mvnw.cmd test
-
-cd ..\catalog-service
-.\mvnw.cmd test
-```
-
-Run all service test commands during broad local verification:
+Run all service suites on PowerShell:
 
 ```powershell
 foreach ($service in 'gateway-service','catalog-service','user-service','engagement-service','recommendation-service') {
@@ -414,189 +207,76 @@ foreach ($service in 'gateway-service','catalog-service','user-service','engagem
 }
 ```
 
-Use the full loop when you want a complete local signal before publishing a broad change.
+## Running locally
 
-### API docs and ports
+### Requirements
 
-Springdoc OpenAPI is configured in the domain services. For direct service runs, open these paths on the service port you assigned:
+- Docker and Docker Compose
+- Java 21 for direct Maven execution
+- `.env` based on `.env.example`
 
-| Service | Swagger UI | OpenAPI JSON |
-|---|---|---|
-| User | `/swagger-ui/index.html` | `/v3/api-docs` |
-| Catalog | `/swagger-ui/index.html` | `/v3/api-docs` |
-| Engagement | `/swagger-ui/index.html` | `/v3/api-docs` |
-| Recommendation | `/swagger-ui/index.html` | `/v3/api-docs` |
+Required configuration includes database credentials, a Base64 JWT key, Google client ID, and allowed origins.
 
-The gateway exposes Actuator endpoints, not a Springdoc UI. Its route prefixes are the public API surface. Service-local Swagger pages are for development and inspection.
+Start the default stack:
 
----
+```bash
+docker compose up -d --build
+```
 
-## Observability
-
-The optional observability profile provides a complete local signal without external infrastructure. It combines service metrics, structured logs, traces, dashboards, alerts, and runbooks.
-
-Enable it with:
+Start with observability:
 
 ```bash
 docker compose --profile observability up -d --build
 ```
 
-### Local observability endpoints
+Useful local endpoints:
 
-| Component | URL | Purpose |
-|---|---|---|
-| Prometheus | `http://localhost:9090` | Scrapes service metrics from `/actuator/prometheus` |
-| Grafana | `http://localhost:3002` | Dashboards, Explore, and provisioned datasources |
-| Loki | `http://localhost:3100` | Stores structured Docker logs collected by Alloy |
-| Tempo | `http://localhost:3200` | Stores traces sent through Alloy |
-| Alloy | `http://localhost:12345` | Collects Docker logs and forwards OTLP traces |
-| Kafka UI | `http://localhost:8090` | Topic and consumer-group inspection |
+| Component | URL |
+|---|---|
+| API Gateway | `http://localhost:8080` |
+| Kafka UI | `http://localhost:8090` |
+| Grafana | `http://localhost:3002` |
+| Prometheus | `http://localhost:9090` |
 
-Grafana is provisioned with Prometheus, Loki, and Tempo datasources plus these dashboards:
+## Design decisions
 
-- `VellumHub Overview`
-- `Gateway and HTTP`
-- `Services JVM and DB`
-- `Kafka Flow`
-- `Recommendation Health`
+| Decision | Trade-off |
+|---|---|
+| Service-owned databases | Clear ownership and deployability, at the cost of eventual consistency and projection complexity |
+| Kafka-fed local read models | Removes serving-time fan-out, but requires contract discipline and recovery paths |
+| PostgreSQL + pgvector | Keeps vectors near relational metadata, but does not target every specialized vector-database feature |
+| In-process embeddings | Removes a sidecar and network hop, while tying model memory and runtime behavior to the JVM service |
+| Retry topics + DLT | Makes failures inspectable, but does not replace idempotency or replay tooling |
+| Gateway plus downstream JWT validation | Adds defense in depth, with duplicated validation work |
+| Optional observability profile | Keeps the default stack lighter, while requiring an explicit profile for full telemetry |
 
-### Actuator endpoints
+## Known limitations
 
-Services expose Spring Boot Actuator endpoints:
-
-- `/actuator/health`
-- `/actuator/info`
-- `/actuator/metrics`
-- `/actuator/prometheus`
-
-`/actuator/prometheus` is backed by the Micrometer Prometheus registry and exports metrics with a common `service` tag. Prometheus scrapes the gateway, user, catalog, engagement, and recommendation services on the Docker network.
-
-### Custom metrics
-
-Custom application metrics use the `vellumhub_*` prefix with intentionally low-cardinality labels: `service`, `topic`, `event_type`, `consumer_group`, `operation`, and `result`.
-
-Kafka and DLT metrics:
-
-- `vellumhub_kafka_events_published_total`
-- `vellumhub_kafka_events_publish_failed_total`
-- `vellumhub_kafka_events_consumed_total`
-- `vellumhub_kafka_events_consume_failed_total`
-- `vellumhub_kafka_event_processing_duration_seconds_count`
-- `vellumhub_kafka_event_processing_duration_seconds_sum`
-- `vellumhub_kafka_dlt_events_total`
-
-Business metrics:
-
-- `vellumhub_users_total`
-- `vellumhub_books_total`
-- `vellumhub_books_updated_total`
-- `vellumhub_books_deleted_total`
-- `vellumhub_reading_progress_updated_total`
-- `vellumhub_ratings_total`
-- `vellumhub_reactions_changed_total`
-- `vellumhub_recommendations_requested_total`
-- `vellumhub_recommendations_generated_total`
-- `vellumhub_recommendation_empty_results_total`
-- `vellumhub_recommendation_generation_duration_seconds_count`
-- `vellumhub_recommendation_generation_duration_seconds_sum`
-
-The Kafka metrics cover producer success/failure, consumer success/failure, processing duration, and DLT quarantine. Business metrics cover user registration/admin creation, catalog book lifecycle, reading progress updates, ratings, reactions, and recommendation generation. Recommendation metrics distinguish empty results from generated non-empty results.
-
-Structured logs flow from application containers to Loki through Alloy. DLT logs include original topic, DLT topic, exception message, and payload byte length without printing raw Kafka payloads by default.
-
-Traces are emitted by the OpenTelemetry Java Agent and forwarded through Alloy to Tempo. Metrics and logs intentionally stay on the Micrometer/Prometheus and Docker-log/Loki paths.
-
-Operational documentation:
-
-- [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md)
-- [docs/OBSERVABILITY_RUNBOOKS.md](docs/OBSERVABILITY_RUNBOOKS.md)
-- [docs/KAFKA_MONITORING.md](docs/KAFKA_MONITORING.md)
-
-The code-level topic inventory in this README is newer than parts of the Kafka monitoring document.
-
----
-
-## Quality and Test Coverage
-
-### Static footprint
-
-| Service | Main Java | Test Java | Controllers | Kafka listeners | Use cases |
-|---|---:|---:|---:|---:|---:|
-| `gateway-service` | 3 | 1 | 0 | 0 | 0 |
-| `user-service` | 58 | 15 | 3 | 0 | 1 |
-| `catalog-service` | 158 | 34 | 7 | 0 | 20 |
-| `engagement-service` | 96 | 11 | 3 | 5 | 12 |
-| `recommendation-service` | 78 | 31 | 2 | 9 | 11 |
-| **Total** | **393** | **92** | **15** | **14** | **44** |
-
-### What the tests target
-
-The current test suite is strongest around domain behavior and adapter boundaries:
-
-- `catalog-service`: book lifecycle, book requests, book lists, memberships, reading progress, handlers, use cases, and controller behavior.
-- `recommendation-service`: user profile vector learning, embedding providers, recommendation use cases, Kafka consumers, mappers, repository adapters, and controller responses.
-- `user-service`: auth flows, user handlers/controllers, password validation, security helpers, and user preference event publication.
-- `engagement-service`: rating use cases, request context, book snapshot use cases, and reading-session event publishing/consumption paths.
-- `gateway-service`: Spring application and gateway configuration smoke coverage.
-
-The next quality step is integration coverage for real Kafka/PostgreSQL behavior with Testcontainers, especially retry/DLT, topic contracts, idempotency, and projection updates.
-
-### Recorded passing test runs
-
-Latest recorded passing local verification in this workspace was performed on 2026-05-25.
-
-| Service | Command | Status |
-|---|---|---|
-| `gateway-service` | `.\mvnw.cmd test` | Passing: 1 test, 0 failures, 0 errors |
-| `catalog-service` | `.\mvnw.cmd test` | Passing: 142 tests, 0 failures, 0 errors |
-
-### Current quality bar
-
-- Every service has its own Maven wrapper and Dockerfile.
-- Unit and slice tests cover domain models, use cases, controllers, Kafka consumers, mappers, and repository adapters in the strongest-covered services.
-- Kafka retry/DLT behavior is implemented in engagement and recommendation, but end-to-end retry/DLT verification still needs Testcontainers coverage.
-- Docker Compose defines service healthchecks for gateway, databases, Redis, Kafka, and application services.
-- Actuator, metrics, Prometheus endpoints, structured logs, OpenTelemetry Java Agent traces, Kafka UI, and the optional Grafana/Prometheus/Loki/Tempo/Alloy profile provide local operational inspection.
-- Coverage percentage is not claimed because no local JaCoCo configuration or generated coverage report was found during inspection.
-- Docker Compose configuration rendered successfully during local inspection, but a full `docker-compose up` health verification was not part of this README pass.
-
----
+- Benchmark numbers are local and need a reproducible public harness with hardware, dataset, warm-up, and percentile reporting.
+- Transactional outbox and complete consumer idempotency remain hardening work.
+- Distributed-flow tests do not yet cover every Kafka/PostgreSQL failure mode.
+- Full production security review, secret management, and deployment automation are outside the current portfolio scope.
 
 ## Roadmap
 
-VellumHub is currently focused on correctness and operational resilience. The next phase is not about adding more endpoints; it is about making the existing platform safer under real distributed-system failure modes.
+The active roadmap prioritizes correctness over additional CRUD surface:
 
-| Area | Goal | Issue |
-|---|---|---|
-| Kafka contracts | Centralize topic names, align producers/consumers/retry configs, and add drift-detection tests | [#199](https://github.com/Luca5Eckert/VellumHub/issues/199) |
-| Consumer idempotency | Add `processed_events` handling for at-least-once Kafka delivery | [#200](https://github.com/Luca5Eckert/VellumHub/issues/200) |
-| Transactional outbox | Persist catalog and engagement changes atomically with outgoing events | [#201](https://github.com/Luca5Eckert/VellumHub/issues/201), [#202](https://github.com/Luca5Eckert/VellumHub/issues/202) |
-| Distributed tracing | Add manual domain spans or Kafka propagation where automatic OTEL instrumentation is insufficient | [#204](https://github.com/Luca5Eckert/VellumHub/issues/204) |
-| Database migrations | Replace production `ddl-auto=update` behavior with Flyway migrations and validation | [#205](https://github.com/Luca5Eckert/VellumHub/issues/205) |
-| Operational security | Harden Actuator exposure, secret defaults, and production logging | [#206](https://github.com/Luca5Eckert/VellumHub/issues/206) |
-| Integration tests | Add Testcontainers coverage for PostgreSQL, Kafka, retry/DLT, and projection flows | [#207](https://github.com/Luca5Eckert/VellumHub/issues/207) |
+1. contract drift detection;
+2. idempotent consumers;
+3. transactional outbox;
+4. Flyway validation across services;
+5. trace propagation through Kafka boundaries;
+6. Testcontainers-based distributed-flow tests;
+7. operational security hardening.
 
----
+## Repository layout
 
-## Design Decisions
+```text
+services/   application services
+infra/      Docker, scripts, and observability configuration
+docs/       architecture and operational documentation
+```
 
-| Decision | Rationale |
-|---|---|
-| Service-owned databases | Keeps domain ownership explicit, avoids hidden coupling through shared tables, and makes each service independently deployable. |
-| Event-carried state transfer over synchronous reads | Lets recommendation and engagement serve from local state in critical paths while accepting eventual consistency. |
-| PostgreSQL + pgvector | Keeps vector search close to relational metadata, transactions, joins, and local Docker workflows. |
-| HNSW cosine search | Provides approximate nearest-neighbor retrieval for dense embeddings with a practical speed/recall tradeoff suitable for the candidate pool size. |
-| In-process LangChain4j embeddings | Removes a separate ML sidecar from the request path, keeps the platform JVM-based, and improves local recommendation latency. |
-| Retry topics + DLT | Makes event processing failures visible and inspectable instead of silently losing state transitions through local exception swallowing. |
-| Gateway plus downstream JWT validation | Uses the gateway as the ingress boundary without making it the only security boundary. |
-| Optional observability profile | Keeps the default local stack lighter while still allowing full metrics, logs, traces, and dashboards when operational inspection is needed. |
+## Author
 
----
-
-## References
-
-- [GitHub README guidance](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes)
-- [Spring Kafka retry topic configuration](https://docs.spring.io/spring-kafka/reference/retrytopic/retry-config.html)
-- [Spring Cloud Gateway reference](https://docs.spring.io/spring-cloud-gateway/docs/current/reference/html/)
-- [LangChain4j in-process embeddings](https://docs.langchain4j.dev/integrations/embedding-models/in-process/)
-- [pgvector HNSW and cosine search](https://github.com/pgvector/pgvector)
+Built by [Lucas Eckert](https://lucas-eckert.vercel.app).

--- a/docs/adr/ADR-001-local-recommendation-read-models.md
+++ b/docs/adr/ADR-001-local-recommendation-read-models.md
@@ -1,0 +1,133 @@
+# ADR-001 - Local Recommendation Read Models
+
+- Status: Accepted
+- Scope: Recommendation serving and upstream state propagation
+- Decision owner: Lucas Eckert
+- Last reviewed: 2026-07-26
+
+## Context
+
+The recommendation service needs catalog metadata, user preference state, ratings, reactions, and reading progress to produce personalized results.
+
+A request-time design could call catalog, user, and engagement services synchronously. That would make recommendation latency and availability depend on every upstream service and would turn partial failures into user-facing recommendation failures.
+
+An earlier architecture also used a Python ML sidecar for embedding and retrieval work, adding another runtime, deployment unit, and network boundary.
+
+## Decision
+
+Use Event-Carried State Transfer to maintain recommendation-owned read models:
+
+1. source services own business writes and their databases;
+2. source services publish business events through Kafka;
+3. recommendation consumers update local projection tables;
+4. recommendation serving reads only from its own PostgreSQL/pgvector database;
+5. embeddings are generated in-process on the JVM;
+6. HNSW cosine search retrieves vector candidates locally;
+7. retry topics and Dead Letter Topics expose asynchronous processing failures.
+
+The recommendation hot path must not synchronously call catalog, user, or engagement services.
+
+## Local state
+
+The recommendation service owns derived tables for:
+
+- book embeddings and popularity signals;
+- user profile vectors and interaction history;
+- denormalized book metadata required to build responses.
+
+These tables are projections, not competing sources of truth. Source services remain authoritative for their business domains.
+
+## Alternatives considered
+
+### Synchronous upstream composition
+
+Advantages:
+
+- latest source state at request time;
+- fewer local projections;
+- simpler write-side event model.
+
+Rejected because one slow or unavailable upstream service would degrade the full recommendation request. It also creates request-time fan-out and tighter release coupling.
+
+### Shared database tables
+
+Advantages:
+
+- direct joins;
+- no event propagation delay;
+- fewer duplicated fields.
+
+Rejected because shared application tables hide ownership and couple service deployments and schema evolution.
+
+### External Python embedding sidecar
+
+Advantages:
+
+- broad Python ML ecosystem;
+- independent model deployment.
+
+Replaced in the current path because it added a network hop and another runtime boundary for a model available in-process on the JVM.
+
+### Specialized vector database
+
+Advantages:
+
+- broader vector-native operational and indexing features.
+
+Not selected for the current system because PostgreSQL/pgvector keeps vectors close to relational metadata, local transactions, and the existing Docker workflow.
+
+## Consequences
+
+### Positive
+
+- Recommendation serving has zero synchronous upstream fan-out.
+- Partial upstream outages do not automatically make local recommendation reads unavailable.
+- Data ownership remains explicit.
+- The Python sidecar and network hop are removed from the serving path.
+- Kafka failure paths are inspectable through retry and DLT behavior.
+- Local read models can be indexed and shaped for recommendation queries.
+
+### Negative
+
+- Recommendation state is eventually consistent.
+- Event contracts become critical compatibility surfaces.
+- Consumers need idempotency, replay, and recovery strategies.
+- Projection schemas duplicate selected upstream fields.
+- Transactional outbox behavior is required to close write/event consistency gaps.
+- Local embedding inference consumes JVM memory and CPU.
+
+## Evidence
+
+Current project evidence:
+
+- five application services;
+- zero synchronous calls to catalog, user, or engagement in the recommendation hot path;
+- latest consolidated validation: 478 Maven tests passing;
+- local benchmark notes: approximately 300-500 ms with the previous Python sidecar and 80-120 ms with in-process JVM embeddings and pgvector.
+
+The latency values are local project benchmarks, not production SLAs.
+
+## Operational requirements
+
+This decision requires:
+
+- centralized topic contracts;
+- idempotent consumers;
+- transactional event publication;
+- retry and DLT monitoring;
+- consumer lag and projection health metrics;
+- integration tests using real Kafka and PostgreSQL behavior;
+- replay and repair procedures for stale projections.
+
+## Current gaps
+
+- The benchmark needs a reproducible public harness with hardware, dataset, warm-up, and percentile reporting.
+- Consumer idempotency and transactional outbox remain active hardening work.
+- Not every distributed failure path is covered by Testcontainers.
+- Projection freshness is not yet exposed as a user-facing SLO.
+
+## Related documentation
+
+- [VellumHub README](../../README.md)
+- [Observability](../OBSERVABILITY.md)
+- [Observability runbooks](../OBSERVABILITY_RUNBOOKS.md)


### PR DESCRIPTION
## What changed

- Replaced the long inventory-style README with a concise problem / decision / result narrative.
- Preserved the confirmed latest validation of **478 Maven tests passing**.
- Made the recommendation hot-path boundary explicit: **zero synchronous calls** to catalog, user, or engagement services.
- Kept the local benchmark of ~300-500 ms to ~80-120 ms, explicitly scoped as a local project measurement rather than a production SLA.
- Documented architecture, core flows, Kafka resilience, gateway security, observability, verification, trade-offs, limitations, and roadmap.
- Added a public ADR for Kafka-fed local recommendation read models, including alternatives and consequences.

## Why

The previous README demonstrated technical breadth but mixed implemented behavior, roadmap work, and production-oriented language. This version prioritizes evidence that can be defended in interviews and clearly separates current behavior from hardening work.

## Scope

Documentation only. No application behavior or configuration was changed.

This PR remains draft for technical accuracy review.