### PR TITLE
#232 feat: implement kubernetes for gitops

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The current architecture is a mature v3 platform moving through v4 reliability h
 - [Kafka Event Contracts](#kafka-event-contracts)
 - [Kafka Resilience](#kafka-resilience)
 - [Gateway and Security](#gateway-and-security)
+- [CI/CD and GitOps](#cicd-and-gitops)
+- [Kubernetes](#kubernetes)
 - [Running Locally](#running-locally)
 - [Observability](#observability)
 - [Quality and Test Coverage](#quality-and-test-coverage)
@@ -291,6 +293,36 @@ The gateway is built with Spring Cloud Gateway on WebFlux and Project Reactor. I
 
 ---
 
+## CI/CD and GitOps
+
+GitHub Actions validates every change before publication: Maven verification, Testcontainers coverage where available, image build validation, and vulnerability scanning. After a merge to `main`, the publication workflow creates one immutable GHCR image per service, tagged with the commit SHA:
+
+- `ghcr.io/luca5eckert/vellumhub-gateway`
+- `ghcr.io/luca5eckert/vellumhub-user`
+- `ghcr.io/luca5eckert/vellumhub-catalog`
+- `ghcr.io/luca5eckert/vellumhub-engagement`
+- `ghcr.io/luca5eckert/vellumhub-recommendation`
+
+The delivery boundary is Git, not a CI-held cluster credential. A reviewed change to `deploy/kubernetes/overlays/prod/kustomization.yaml` declares the exact SHA (or a digest) to run. Argo CD observes that desired state and reconciles it in the cluster. It starts with manual sync; enable automated `prune` and `selfHeal` only after the first controlled production sync.
+
+The rollback is also Git-based: revert the commit that changes the image version, sync Argo CD, wait for the rolling update, then run the smoke checks. `latest` is never used as a deployment version.
+
+## Kubernetes
+
+Kubernetes manifests live in [`deploy/kubernetes`](deploy/kubernetes). Kustomize keeps application workload definitions separate from stateful infrastructure:
+
+- `base`: namespace `vellumhub`, five hardened Deployments, five internal Services, ingress, ConfigMap interface, probes, and security baseline.
+- `overlays/local`: one replica per application plus in-cluster Redis, KRaft Kafka, four PostgreSQL databases, pgvector, and PVCs.
+- `overlays/prod`: multiple stateless replicas, gateway PDB, and incremental NetworkPolicies; PostgreSQL, Kafka, Redis, and secrets are supplied externally.
+- `argocd`: the pull-based Argo CD `Application` definition.
+
+Only `gateway-service` has an Ingress. All application containers use Spring Boot liveness/readiness endpoints, run as non-root, drop Linux capabilities, use resource requests/limits, and roll out new Pods only after readiness succeeds. The recommendation service has a longer startup window and a higher memory baseline for embedding initialization.
+
+Non-sensitive endpoints are supplied by ConfigMap; `JWT_KEY`, database credentials, and OAuth values are consumed through `vellumhub-secrets` and are not versioned. Kubernetes Secrets are an interface only; production should source them from a managed secret system.
+
+For the supported local-cluster bootstrap, smoke checks, resource rationale, and rollback procedure, see [`deploy/kubernetes/README.md`](deploy/kubernetes/README.md).
+
+---
 ## Running Locally
 
 ### Prerequisites

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,0 +1,51 @@
+# VellumHub on Kubernetes
+
+This directory is the desired state for the five application services. It never builds source in the cluster and every image reference must be a published immutable Git SHA (or preferably a digest).
+
+## Layout
+
+- `base`: namespace, configuration interface, five ClusterIP services, ingress and hardened application Deployments.
+- `overlays/local`: one replica and in-cluster PostgreSQL, pgvector, Redis and KRaft Kafka with PVCs.
+- `overlays/prod`: stateless applications only; database, Kafka and Redis endpoints must point to managed/external services.
+- `argocd`: pull-based GitOps application definition.
+
+The four database Services preserve ownership: `user_db`, `catalog_db`, `engagement_db`, and `recommendation_db`. The latter runs a pgvector image; Flyway remains the only owner of application tables.
+
+## Local bootstrap (kind)
+
+Prerequisites: Docker, `kind`, `kubectl`, and `kustomize` (or `kubectl kustomize`). The images must already have been published by CI and be readable by the cluster. For private GHCR packages, create `imagePullSecrets` separately and attach it through an environment overlay.
+
+```powershell
+kind create cluster --name vellumhub
+kubectl apply -f deploy/kubernetes/base/config/secret.example.yaml # copy/edit it first; never commit the edited file
+kubectl apply -k deploy/kubernetes/overlays/local
+kubectl rollout status deployment/gateway-service -n vellumhub --timeout=10m
+kubectl get pods,services,ingress,pvc -n vellumhub
+```
+
+Install an NGINX Ingress controller using its documented kind installation, map `vellumhub.local` to `127.0.0.1`, then run:
+
+```powershell
+.\deploy\kubernetes\scripts\smoke-kubernetes.ps1
+```
+
+If ingress is not installed, access the gateway temporarily with `kubectl port-forward -n vellumhub service/gateway-service 8080:8080`; run only deployment and DNS parts of the smoke script until a gateway URL is available.
+
+Destroy the local cluster with `kind delete cluster --name vellumhub`. This removes the cluster PVCs.
+
+## Production and GitOps
+
+Create the `vellumhub-secrets` Secret through External Secrets/your managed secret system; Kubernetes Secrets are an interface, not a production secret manager. Configure the production ConfigMap patch with external RDS/MSK/ElastiCache endpoints. Do not apply local stateful resources in production.
+
+Bootstrap Argo CD separately with least-privilege permissions to the `vellumhub` namespace, then apply `argocd/vellumhub.yaml`. It starts in manual sync mode deliberately. After a verified sync, opt into `automated: { prune: true, selfHeal: true }` through review; `prune` deletes resources removed from Git and needs deliberate ownership boundaries.
+
+CI updates only the SHA/digest in an overlay `images` block. It receives no cluster-admin credential. Argo CD pulls Git, detects the change, and rolls out only ready Pods. The gateway PDB applies only to production’s two replicas; it is intentionally absent locally.
+
+## Rollout and rollback
+
+1. Commit image version A and sync Argo CD; verify `kubectl rollout status` and smoke tests.
+2. Commit version B, sync, and confirm the deployed image with `kubectl get pods -n vellumhub -o jsonpath='{..image}'`.
+3. Revert the Git commit that changed the image reference and sync Argo CD again.
+4. Confirm all five rollouts and smoke tests are healthy.
+
+The resource baseline is intentionally modest: gateway/user 512Mi request, catalog/engagement 640Mi, recommendation 1Gi because its embedding model has higher startup and heap demand. These are starting measurements for local operation, not production sizing; tune from JVM/container metrics before enabling HPA. HPA is deferred until Metrics Server and a measured baseline exist.

--- a/deploy/kubernetes/argocd/vellumhub.yaml
+++ b/deploy/kubernetes/argocd/vellumhub.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vellumhub
+  namespace: argocd
+  labels: {app.kubernetes.io/part-of: vellumhub}
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Luca5Eckert/VellumHub.git
+    targetRevision: main
+    path: deploy/kubernetes/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vellumhub
+  syncPolicy:
+    # Start with manual sync. Enable automated only after a controlled deployment.
+    syncOptions: [CreateNamespace=true, PrunePropagationPolicy=foreground]

--- a/deploy/kubernetes/base/applications.yaml
+++ b/deploy/kubernetes/base/applications.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Service
+metadata: {name: gateway-service, labels: {app.kubernetes.io/name: gateway-service}}
+spec: {type: ClusterIP, selector: {app.kubernetes.io/name: gateway-service}, ports: [{name: http, port: 8080, targetPort: http}]}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: user-service, labels: {app.kubernetes.io/name: user-service}}
+spec: {type: ClusterIP, selector: {app.kubernetes.io/name: user-service}, ports: [{name: http, port: 8080, targetPort: http}]}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: catalog-service, labels: {app.kubernetes.io/name: catalog-service}}
+spec: {type: ClusterIP, selector: {app.kubernetes.io/name: catalog-service}, ports: [{name: http, port: 8080, targetPort: http}]}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: engagement-service, labels: {app.kubernetes.io/name: engagement-service}}
+spec: {type: ClusterIP, selector: {app.kubernetes.io/name: engagement-service}, ports: [{name: http, port: 8080, targetPort: http}]}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: recommendation-service, labels: {app.kubernetes.io/name: recommendation-service}}
+spec: {type: ClusterIP, selector: {app.kubernetes.io/name: recommendation-service}, ports: [{name: http, port: 8080, targetPort: http}]}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: gateway-service, labels: {app.kubernetes.io/name: gateway-service, app.kubernetes.io/part-of: vellumhub}}
+spec:
+  replicas: 2
+  strategy: {type: RollingUpdate, rollingUpdate: {maxUnavailable: 0, maxSurge: 1}}
+  selector: {matchLabels: {app.kubernetes.io/name: gateway-service}}
+  template:
+    metadata: {labels: {app.kubernetes.io/name: gateway-service, app.kubernetes.io/part-of: vellumhub}}
+    spec:
+      terminationGracePeriodSeconds: 35
+      securityContext: {seccompProfile: {type: RuntimeDefault}}
+      containers:
+        - name: gateway-service
+          image: ghcr.io/luca5eckert/vellumhub-gateway:REPLACE_WITH_IMMUTABLE_TAG
+          imagePullPolicy: IfNotPresent
+          ports: [{name: http, containerPort: 8080}]
+          env:
+            - {name: SPRING_PROFILES_ACTIVE, value: prod}
+            - {name: SERVER_PORT, value: "8080"}
+            - {name: USER_SERVICE_URL, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: USER_SERVICE_URL}}}
+            - {name: CATALOG_SERVICE_URL, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: CATALOG_SERVICE_URL}}}
+            - {name: ENGAGEMENT_SERVICE_URL, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: ENGAGEMENT_SERVICE_URL}}}
+            - {name: RECOMMENDATION_SERVICE_URL, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: RECOMMENDATION_SERVICE_URL}}}
+            - {name: SPRING_DATA_REDIS_HOST, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: SPRING_DATA_REDIS_HOST}}}
+            - {name: SPRING_DATA_REDIS_PORT, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: SPRING_DATA_REDIS_PORT}}}
+            - {name: VELLUM_ENVIRONMENT, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: VELLUM_ENVIRONMENT}}}
+            - {name: CORS_ALLOWED_ORIGINS, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: CORS_ALLOWED_ORIGINS}}}
+            - {name: JWT_KEY, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: JWT_KEY}}}
+          resources: {requests: {cpu: 200m, memory: 512Mi}, limits: {cpu: "1", memory: 768Mi}}
+          securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, runAsNonRoot: true, runAsUser: 10001, capabilities: {drop: [ALL]}}
+          startupProbe: {httpGet: {path: /actuator/health/liveness, port: http}, periodSeconds: 5, failureThreshold: 24}
+          livenessProbe: {httpGet: {path: /actuator/health/liveness, port: http}, periodSeconds: 15, failureThreshold: 3}
+          readinessProbe: {httpGet: {path: /actuator/health/readiness, port: http}, periodSeconds: 10, failureThreshold: 3}

--- a/deploy/kubernetes/base/catalog.yaml
+++ b/deploy/kubernetes/base/catalog.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: catalog-service, labels: {app.kubernetes.io/name: catalog-service, app.kubernetes.io/part-of: vellumhub}}
+spec:
+  replicas: 2
+  strategy: {type: RollingUpdate, rollingUpdate: {maxUnavailable: 0, maxSurge: 1}}
+  selector: {matchLabels: {app.kubernetes.io/name: catalog-service}}
+  template:
+    metadata: {labels: {app.kubernetes.io/name: catalog-service, app.kubernetes.io/part-of: vellumhub}}
+    spec:
+      terminationGracePeriodSeconds: 35
+      securityContext: {seccompProfile: {type: RuntimeDefault}}
+      containers:
+        - name: catalog-service
+          image: ghcr.io/luca5eckert/vellumhub-catalog:REPLACE_WITH_IMMUTABLE_TAG
+          ports: [{name: http, containerPort: 8080}]
+          env: &jdbcKafkaEnv
+            - {name: SPRING_PROFILES_ACTIVE, value: prod}
+            - {name: SERVER_PORT, value: "8080"}
+            - {name: SPRING_DATASOURCE_URL, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: CATALOG_DATASOURCE_URL}}}
+            - {name: KAFKA_BOOTSTRAP_SERVERS, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: KAFKA_BOOTSTRAP_SERVERS}}}
+            - {name: VELLUM_ENVIRONMENT, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: VELLUM_ENVIRONMENT}}}
+            - {name: CORS_ALLOWED_ORIGINS, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: CORS_ALLOWED_ORIGINS}}}
+            - {name: JWT_KEY, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: JWT_KEY}}}
+            - {name: SPRING_DATASOURCE_USERNAME, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_USER}}}
+            - {name: SPRING_DATASOURCE_PASSWORD, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_PASSWORD}}}
+          resources: {requests: {cpu: 250m, memory: 640Mi}, limits: {cpu: "1", memory: 1Gi}}
+          securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, runAsNonRoot: true, runAsUser: 10001, capabilities: {drop: [ALL]}}
+          startupProbe: {httpGet: {path: /actuator/health/liveness, port: http}, periodSeconds: 5, failureThreshold: 30}
+          livenessProbe: {httpGet: {path: /actuator/health/liveness, port: http}, periodSeconds: 15, failureThreshold: 3}
+          readinessProbe: {httpGet: {path: /actuator/health/readiness, port: http}, periodSeconds: 10, failureThreshold: 3}

--- a/deploy/kubernetes/base/config/app-config.yaml
+++ b/deploy/kubernetes/base/config/app-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vellumhub-config
+data:
+  VELLUM_ENVIRONMENT: production
+  CORS_ALLOWED_ORIGINS: https://example.invalid
+  USER_SERVICE_URL: http://user-service:8080
+  CATALOG_SERVICE_URL: http://catalog-service:8080
+  ENGAGEMENT_SERVICE_URL: http://engagement-service:8080
+  RECOMMENDATION_SERVICE_URL: http://recommendation-service:8080
+  SPRING_DATA_REDIS_HOST: redis
+  SPRING_DATA_REDIS_PORT: "6379"
+  KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+  USER_DATASOURCE_URL: jdbc:postgresql://user-postgres:5432/user_db
+  CATALOG_DATASOURCE_URL: jdbc:postgresql://catalog-postgres:5432/catalog_db
+  ENGAGEMENT_DATASOURCE_URL: jdbc:postgresql://engagement-postgres:5432/engagement_db
+  RECOMMENDATION_DATASOURCE_URL: jdbc:postgresql://recommendation-postgres:5432/recommendation_db

--- a/deploy/kubernetes/base/config/secret.example.yaml
+++ b/deploy/kubernetes/base/config/secret.example.yaml
@@ -1,0 +1,13 @@
+# Copy this file outside version control, replace placeholders, then apply it.
+# Kubernetes Secrets are only an interface here; use an external secret manager in production.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vellumhub-secrets
+type: Opaque
+stringData:
+  JWT_KEY: replace-with-a-long-random-value
+  POSTGRES_USER: vellumhub
+  POSTGRES_PASSWORD: replace-with-a-strong-password
+  JWT_EXPIRATION_MS: "3600000"
+  GOOGLE_CLIENT_ID: replace-when-google-login-is-enabled

--- a/deploy/kubernetes/base/ingress.yaml
+++ b/deploy/kubernetes/base/ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gateway-service
+  annotations: {nginx.ingress.kubernetes.io/proxy-read-timeout: "60"}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: vellumhub.local
+      http:
+        paths:
+          - path: /api/v1
+            pathType: Prefix
+            backend: {service: {name: gateway-service, port: {name: http}}}

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: vellumhub
+resources:
+  - namespace.yaml
+  - config/app-config.yaml
+  - applications.yaml
+  - user.yaml
+  - catalog.yaml
+  - remaining-services.yaml
+  - ingress.yaml
+  - network-policy.yaml

--- a/deploy/kubernetes/base/namespace.yaml
+++ b/deploy/kubernetes/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vellumhub
+  labels:
+    app.kubernetes.io/part-of: vellumhub

--- a/deploy/kubernetes/base/network-policy.yaml
+++ b/deploy/kubernetes/base/network-policy.yaml
@@ -1,0 +1,13 @@
+# Requires a CNI that enforces NetworkPolicy. DNS egress remains allowed for service discovery.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: default-deny, labels: {app.kubernetes.io/part-of: vellumhub}}
+spec: {podSelector: {}, policyTypes: [Ingress, Egress]}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: allow-dns, labels: {app.kubernetes.io/part-of: vellumhub}}
+spec:
+  podSelector: {}
+  policyTypes: [Egress]
+  egress: [{to: [{namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: kube-system}}}], ports: [{protocol: UDP, port: 53}, {protocol: TCP, port: 53}]}]

--- a/deploy/kubernetes/base/remaining-services.yaml
+++ b/deploy/kubernetes/base/remaining-services.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: engagement-service, labels: {app.kubernetes.io/name: engagement-service, app.kubernetes.io/part-of: vellumhub}}
+spec:
+  replicas: 2
+  strategy: {type: RollingUpdate, rollingUpdate: {maxUnavailable: 0, maxSurge: 1}}
+  selector: {matchLabels: {app.kubernetes.io/name: engagement-service}}
+  template:
+    metadata: {labels: {app.kubernetes.io/name: engagement-service, app.kubernetes.io/part-of: vellumhub}}
+    spec:
+      terminationGracePeriodSeconds: 35
+      securityContext: {seccompProfile: {type: RuntimeDefault}}
+      containers:
+        - name: engagement-service
+          image: ghcr.io/luca5eckert/vellumhub-engagement:REPLACE_WITH_IMMUTABLE_TAG
+          ports: [{name: http, containerPort: 8080}]
+          env:
+            - {name: SPRING_PROFILES_ACTIVE, value: prod}
+            - {name: SERVER_PORT, value: "8080"}
+            - {name: SPRING_DATASOURCE_URL, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: ENGAGEMENT_DATASOURCE_URL}}}
+            - {name: KAFKA_BOOTSTRAP_SERVERS, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: KAFKA_BOOTSTRAP_SERVERS}}}
+            - {name: VELLUM_ENVIRONMENT, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: VELLUM_ENVIRONMENT}}}
+            - {name: CORS_ALLOWED_ORIGINS, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: CORS_ALLOWED_ORIGINS}}}
+            - {name: JWT_KEY, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: JWT_KEY}}}
+            - {name: SPRING_DATASOURCE_USERNAME, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_USER}}}
+            - {name: SPRING_DATASOURCE_PASSWORD, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_PASSWORD}}}
+          resources: {requests: {cpu: 250m, memory: 640Mi}, limits: {cpu: "1", memory: 1Gi}}
+          securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, runAsNonRoot: true, runAsUser: 10001, capabilities: {drop: [ALL]}}
+          startupProbe: {httpGet: {path: /actuator/health/liveness, port: http}, periodSeconds: 5, failureThreshold: 30}
+          livenessProbe: {httpGet: {path: /actuator/health/liveness, port: http}, periodSeconds: 15, failureThreshold: 3}
+          readinessProbe: {httpGet: {path: /actuator/health/readiness, port: http}, periodSeconds: 10, failureThreshold: 3}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: recommendation-service, labels: {app.kubernetes.io/name: recommendation-service, app.kubernetes.io/part-of: vellumhub}}
+spec:
+  replicas: 2
+  strategy: {type: RollingUpdate, rollingUpdate: {maxUnavailable: 0, maxSurge: 1}}
+  selector: {matchLabels: {app.kubernetes.io/name: recommendation-service}}
+  template:
+    metadata: {labels: {app.kubernetes.io/name: recommendation-service, app.kubernetes.io/part-of: vellumhub}}
+    spec:
+      terminationGracePeriodSeconds: 60
+      securityContext: {seccompProfile: {type: RuntimeDefault}}
+      containers:
+        - name: recommendation-service
+          image: ghcr.io/luca5eckert/vellumhub-recommendation:REPLACE_WITH_IMMUTABLE_TAG
+          ports: [{name: http, containerPort: 8080}]
+          env:
+            - {name: SPRING_PROFILES_ACTIVE, value: prod}
+            - {name: SERVER_PORT, value: "8080"}
+            - {name: SPRING_MAIN_ALLOW_BEAN_DEFINITION_OVERRIDING, value: "true"}
+            - {name: SPRING_DATASOURCE_URL, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: RECOMMENDATION_DATASOURCE_URL}}}
+            - {name: KAFKA_BOOTSTRAP_SERVERS, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: KAFKA_BOOTSTRAP_SERVERS}}}
+            - {name: VELLUM_ENVIRONMENT, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: VELLUM_ENVIRONMENT}}}
+            - {name: CORS_ALLOWED_ORIGINS, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: CORS_ALLOWED_ORIGINS}}}
+            - {name: JWT_KEY, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: JWT_KEY}}}
+            - {name: SPRING_DATASOURCE_USERNAME, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_USER}}}
+            - {name: SPRING_DATASOURCE_PASSWORD, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_PASSWORD}}}
+          resources: {requests: {cpu: 500m, memory: 1Gi}, limits: {cpu: "2", memory: 2Gi}}
+          securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, runAsNonRoot: true, runAsUser: 10001, capabilities: {drop: [ALL]}}
+          startupProbe: {httpGet: {path: /actuator/health/liveness, port: http}, periodSeconds: 10, failureThreshold: 60}
+          livenessProbe: {httpGet: {path: /actuator/health/liveness, port: http}, periodSeconds: 20, failureThreshold: 3}
+          readinessProbe: {httpGet: {path: /actuator/health/readiness, port: http}, periodSeconds: 15, failureThreshold: 3}

--- a/deploy/kubernetes/base/user.yaml
+++ b/deploy/kubernetes/base/user.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: user-service, labels: {app.kubernetes.io/name: user-service, app.kubernetes.io/part-of: vellumhub}}
+spec:
+  replicas: 2
+  strategy: {type: RollingUpdate, rollingUpdate: {maxUnavailable: 0, maxSurge: 1}}
+  selector: {matchLabels: {app.kubernetes.io/name: user-service}}
+  template:
+    metadata: {labels: {app.kubernetes.io/name: user-service, app.kubernetes.io/part-of: vellumhub}}
+    spec:
+      terminationGracePeriodSeconds: 35
+      securityContext: {seccompProfile: {type: RuntimeDefault}}
+      containers:
+        - name: user-service
+          image: ghcr.io/luca5eckert/vellumhub-user:REPLACE_WITH_IMMUTABLE_TAG
+          ports: [{name: http, containerPort: 8080}]
+          env:
+            - {name: SPRING_PROFILES_ACTIVE, value: prod}
+            - {name: SERVER_PORT, value: "8080"}
+            - {name: SPRING_DATASOURCE_URL, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: USER_DATASOURCE_URL}}}
+            - {name: KAFKA_BOOTSTRAP_SERVERS, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: KAFKA_BOOTSTRAP_SERVERS}}}
+            - {name: VELLUM_ENVIRONMENT, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: VELLUM_ENVIRONMENT}}}
+            - {name: CORS_ALLOWED_ORIGINS, valueFrom: {configMapKeyRef: {name: vellumhub-config, key: CORS_ALLOWED_ORIGINS}}}
+            - {name: JWT_KEY, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: JWT_KEY}}}
+            - {name: JWT_EXPIRATION_MS, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: JWT_EXPIRATION_MS}}}
+            - {name: GOOGLE_CLIENT_ID, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: GOOGLE_CLIENT_ID, optional: true}}}
+            - {name: SPRING_DATASOURCE_USERNAME, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_USER}}}
+            - {name: SPRING_DATASOURCE_PASSWORD, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_PASSWORD}}}
+          resources: {requests: {cpu: 200m, memory: 512Mi}, limits: {cpu: "1", memory: 768Mi}}
+          securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, runAsNonRoot: true, runAsUser: 10001, capabilities: {drop: [ALL]}}
+          startupProbe: {httpGet: {path: /actuator/health/liveness, port: http}, periodSeconds: 5, failureThreshold: 30}
+          livenessProbe: {httpGet: {path: /actuator/health/liveness, port: http}, periodSeconds: 15, failureThreshold: 3}
+          readinessProbe: {httpGet: {path: /actuator/health/readiness, port: http}, periodSeconds: 10, failureThreshold: 3}

--- a/deploy/kubernetes/overlays/local/databases.yaml
+++ b/deploy/kubernetes/overlays/local/databases.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: {name: engagement-postgres}
+spec:
+  serviceName: engagement-postgres
+  replicas: 1
+  selector: {matchLabels: {app: engagement-postgres}}
+  template:
+    metadata: {labels: {app: engagement-postgres}}
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          ports: [{name: postgres, containerPort: 5432}]
+          env:
+            - {name: POSTGRES_DB, value: engagement_db}
+            - {name: POSTGRES_USER, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_USER}}}
+            - {name: POSTGRES_PASSWORD, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_PASSWORD}}}
+          resources: {requests: {cpu: 100m, memory: 256Mi}, limits: {cpu: 500m, memory: 512Mi}}
+          volumeMounts: [{name: data, mountPath: /var/lib/postgresql/data}]
+  volumeClaimTemplates: [{metadata: {name: data}, spec: {accessModes: [ReadWriteOnce], resources: {requests: {storage: 2Gi}}}}]
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: {name: recommendation-postgres}
+spec:
+  serviceName: recommendation-postgres
+  replicas: 1
+  selector: {matchLabels: {app: recommendation-postgres}}
+  template:
+    metadata: {labels: {app: recommendation-postgres}}
+    spec:
+      containers:
+        - name: postgres
+          # pgvector is required by recommendation-service Flyway migrations.
+          image: pgvector/pgvector:pg15
+          ports: [{name: postgres, containerPort: 5432}]
+          env:
+            - {name: POSTGRES_DB, value: recommendation_db}
+            - {name: POSTGRES_USER, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_USER}}}
+            - {name: POSTGRES_PASSWORD, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_PASSWORD}}}
+          resources: {requests: {cpu: 150m, memory: 384Mi}, limits: {cpu: 750m, memory: 768Mi}}
+          volumeMounts: [{name: data, mountPath: /var/lib/postgresql/data}]
+  volumeClaimTemplates: [{metadata: {name: data}, spec: {accessModes: [ReadWriteOnce], resources: {requests: {storage: 3Gi}}}}]

--- a/deploy/kubernetes/overlays/local/infrastructure.yaml
+++ b/deploy/kubernetes/overlays/local/infrastructure.yaml
@@ -1,0 +1,122 @@
+apiVersion: v1
+kind: Service
+metadata: {name: redis}
+spec: {selector: {app: redis}, ports: [{port: 6379, targetPort: redis}]}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: {name: redis}
+spec:
+  serviceName: redis
+  replicas: 1
+  selector: {matchLabels: {app: redis}}
+  template:
+    metadata: {labels: {app: redis}}
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.4-alpine
+          ports: [{name: redis, containerPort: 6379}]
+          args: [redis-server, --appendonly, "yes"]
+          resources: {requests: {cpu: 50m, memory: 64Mi}, limits: {cpu: 250m, memory: 256Mi}}
+          volumeMounts: [{name: data, mountPath: /data}]
+  volumeClaimTemplates: [{metadata: {name: data}, spec: {accessModes: [ReadWriteOnce], resources: {requests: {storage: 1Gi}}}}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: kafka}
+spec: {selector: {app: kafka}, ports: [{name: kafka, port: 9092, targetPort: kafka}]}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: {name: kafka}
+spec:
+  serviceName: kafka
+  replicas: 1
+  selector: {matchLabels: {app: kafka}}
+  template:
+    metadata: {labels: {app: kafka}}
+    spec:
+      containers:
+        - name: kafka
+          image: bitnami/kafka:3.9
+          ports: [{name: kafka, containerPort: 9092}]
+          env:
+            - {name: KAFKA_CFG_NODE_ID, value: "1"}
+            - {name: KAFKA_CFG_PROCESS_ROLES, value: broker,controller}
+            - {name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS, value: 1@kafka-0.kafka:9093}
+            - {name: KAFKA_CFG_LISTENERS, value: PLAINTEXT://:9092,CONTROLLER://:9093}
+            - {name: KAFKA_CFG_ADVERTISED_LISTENERS, value: PLAINTEXT://kafka:9092}
+            - {name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP, value: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT}
+            - {name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES, value: CONTROLLER}
+            - {name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME, value: PLAINTEXT}
+            - {name: KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR, value: "1"}
+            - {name: KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR, value: "1"}
+            - {name: KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR, value: "1"}
+            - {name: ALLOW_PLAINTEXT_LISTENER, value: "yes"}
+          resources: {requests: {cpu: 250m, memory: 512Mi}, limits: {cpu: "1", memory: 1Gi}}
+          volumeMounts: [{name: data, mountPath: /bitnami/kafka}]
+  volumeClaimTemplates: [{metadata: {name: data}, spec: {accessModes: [ReadWriteOnce], resources: {requests: {storage: 5Gi}}}}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: user-postgres}
+spec: {selector: {app: user-postgres}, ports: [{port: 5432, targetPort: postgres}]}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: catalog-postgres}
+spec: {selector: {app: catalog-postgres}, ports: [{port: 5432, targetPort: postgres}]}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: engagement-postgres}
+spec: {selector: {app: engagement-postgres}, ports: [{port: 5432, targetPort: postgres}]}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: recommendation-postgres}
+spec: {selector: {app: recommendation-postgres}, ports: [{port: 5432, targetPort: postgres}]}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: {name: user-postgres}
+spec: &postgresSpec
+  serviceName: user-postgres
+  replicas: 1
+  selector: {matchLabels: {app: user-postgres}}
+  template:
+    metadata: {labels: {app: user-postgres}}
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          ports: [{name: postgres, containerPort: 5432}]
+          env: &postgresEnv
+            - {name: POSTGRES_DB, value: user_db}
+            - {name: POSTGRES_USER, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_USER}}}
+            - {name: POSTGRES_PASSWORD, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_PASSWORD}}}
+          resources: {requests: {cpu: 100m, memory: 256Mi}, limits: {cpu: 500m, memory: 512Mi}}
+          volumeMounts: [{name: data, mountPath: /var/lib/postgresql/data}]
+  volumeClaimTemplates: [{metadata: {name: data}, spec: {accessModes: [ReadWriteOnce], resources: {requests: {storage: 2Gi}}}}]
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: {name: catalog-postgres}
+spec:
+  serviceName: catalog-postgres
+  selector: {matchLabels: {app: catalog-postgres}}
+  template:
+    metadata: {labels: {app: catalog-postgres}}
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          ports: [{name: postgres, containerPort: 5432}]
+          env:
+            - {name: POSTGRES_DB, value: catalog_db}
+            - {name: POSTGRES_USER, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_USER}}}
+            - {name: POSTGRES_PASSWORD, valueFrom: {secretKeyRef: {name: vellumhub-secrets, key: POSTGRES_PASSWORD}}}
+          resources: {requests: {cpu: 100m, memory: 256Mi}, limits: {cpu: 500m, memory: 512Mi}}
+          volumeMounts: [{name: data, mountPath: /var/lib/postgresql/data}]
+  volumeClaimTemplates: [{metadata: {name: data}, spec: {accessModes: [ReadWriteOnce], resources: {requests: {storage: 2Gi}}}}]

--- a/deploy/kubernetes/overlays/local/kustomization.yaml
+++ b/deploy/kubernetes/overlays/local/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - infrastructure.yaml
+  - databases.yaml
+patches:
+  - path: local-patches.yaml
+images:
+  # Load these exact CI-built images into kind, or replace with published SHA tags.
+  - name: ghcr.io/luca5eckert/vellumhub-gateway
+    newTag: REPLACE_WITH_GIT_SHA
+  - name: ghcr.io/luca5eckert/vellumhub-user
+    newTag: REPLACE_WITH_GIT_SHA
+  - name: ghcr.io/luca5eckert/vellumhub-catalog
+    newTag: REPLACE_WITH_GIT_SHA
+  - name: ghcr.io/luca5eckert/vellumhub-engagement
+    newTag: REPLACE_WITH_GIT_SHA
+  - name: ghcr.io/luca5eckert/vellumhub-recommendation
+    newTag: REPLACE_WITH_GIT_SHA

--- a/deploy/kubernetes/overlays/local/local-patches.yaml
+++ b/deploy/kubernetes/overlays/local/local-patches.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: gateway-service}
+spec: {replicas: 1}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: user-service}
+spec: {replicas: 1}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: catalog-service}
+spec: {replicas: 1}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: engagement-service}
+spec: {replicas: 1}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: recommendation-service}
+spec: {replicas: 1}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: default-deny}
+$patch: delete
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: allow-dns}
+$patch: delete

--- a/deploy/kubernetes/overlays/prod/config-patch.yaml
+++ b/deploy/kubernetes/overlays/prod/config-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: vellumhub-config}
+data:
+  VELLUM_ENVIRONMENT: production
+  CORS_ALLOWED_ORIGINS: https://api.example.com
+  # Production supplies these endpoints via an environment-specific overlay.
+  SPRING_DATA_REDIS_HOST: redis.example.internal
+  KAFKA_BOOTSTRAP_SERVERS: kafka.example.internal:9092

--- a/deploy/kubernetes/overlays/prod/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prod/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - pdb.yaml
+  - network-allow.yaml
+patches:
+  - path: config-patch.yaml
+images:
+  - name: ghcr.io/luca5eckert/vellumhub-gateway
+    newTag: REPLACE_WITH_GIT_SHA
+  - name: ghcr.io/luca5eckert/vellumhub-user
+    newTag: REPLACE_WITH_GIT_SHA
+  - name: ghcr.io/luca5eckert/vellumhub-catalog
+    newTag: REPLACE_WITH_GIT_SHA
+  - name: ghcr.io/luca5eckert/vellumhub-engagement
+    newTag: REPLACE_WITH_GIT_SHA
+  - name: ghcr.io/luca5eckert/vellumhub-recommendation
+    newTag: REPLACE_WITH_GIT_SHA

--- a/deploy/kubernetes/overlays/prod/network-allow.yaml
+++ b/deploy/kubernetes/overlays/prod/network-allow.yaml
@@ -1,0 +1,19 @@
+# Incremental policy baseline. Restricts ingress to the service namespace, except the public gateway.
+# Egress is kept open until external database/Kafka CIDRs and observability destinations are known.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: allow-vellumhub-internal}
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from: [{namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: vellumhub}}}]
+  egress: [{}]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: allow-gateway-public-ingress}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: gateway-service}}
+  policyTypes: [Ingress]
+  ingress: [{}]

--- a/deploy/kubernetes/overlays/prod/pdb.yaml
+++ b/deploy/kubernetes/overlays/prod/pdb.yaml
@@ -1,0 +1,6 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata: {name: gateway-service}
+spec:
+  minAvailable: 1
+  selector: {matchLabels: {app.kubernetes.io/name: gateway-service}}

--- a/deploy/kubernetes/scripts/smoke-kubernetes.ps1
+++ b/deploy/kubernetes/scripts/smoke-kubernetes.ps1
@@ -1,0 +1,23 @@
+param(
+  [string]$Namespace = "vellumhub",
+  [string]$GatewayUrl = "http://vellumhub.local"
+)
+
+$ErrorActionPreference = "Stop"
+$deployments = @("gateway-service", "user-service", "catalog-service", "engagement-service", "recommendation-service")
+foreach ($deployment in $deployments) {
+  kubectl rollout status "deployment/$deployment" -n $Namespace --timeout=10m
+}
+
+foreach ($path in @("/actuator/health/liveness", "/actuator/health/readiness")) {
+  $response = Invoke-WebRequest -UseBasicParsing -Uri "$GatewayUrl$path" -TimeoutSec 30
+  if ($response.StatusCode -ne 200) { throw "Gateway $path returned $($response.StatusCode)" }
+}
+
+# DNS and backing-service connectivity are asserted from the running gateway Pod.
+$gatewayPod = kubectl get pod -n $Namespace -l app.kubernetes.io/name=gateway-service -o jsonpath='{.items[0].metadata.name}'
+if (-not $gatewayPod) { throw "Gateway Pod was not found" }
+foreach ($host in @("user-service", "catalog-service", "engagement-service", "recommendation-service", "redis", "kafka")) {
+  kubectl exec -n $Namespace $gatewayPod -- sh -c "getent hosts $host" | Out-Null
+}
+Write-Host "Kubernetes smoke test passed. Execute authenticated route and Kafka event checks with the test credentials of the target environment."


### PR DESCRIPTION
This pull request introduces a comprehensive Kubernetes deployment and GitOps setup for the VellumHub platform, including manifests for all five application services, configuration management, security controls, and a documented CI/CD pipeline. It adds detailed documentation for local and production operations, and implements a Git-driven, Argo CD-based deployment workflow. The most important changes are:

**Kubernetes Manifests and Application Deployment**
* Added complete Kubernetes manifests for all services in `deploy/kubernetes/base`, including `Deployment` and `Service` definitions for the gateway, user, catalog, engagement, and recommendation services, with secure container settings, resource requests/limits, and health probes. [[1]](diffhunk://#diff-9d1139204b706f74925b020ff628d77ca5cc567e9abb378e13d684ac56ce85aeR1-R59) [[2]](diffhunk://#diff-3876e52b36f3f5a85a4f4427d390ad9e81af8c2d4b3ff037e0da63e2312fe002R1-R31) [[3]](diffhunk://#diff-2cfebb6f756568eab48c9fe1290fd640ce54ececf4e7ae53f0120e062e4e945bR1-R64)
* Introduced a `ConfigMap` (`app-config.yaml`) for environment variables and service endpoints, and a `Secret` example file for sensitive values, with clear separation of configuration and secrets. [[1]](diffhunk://#diff-bc102f56db5d5cb1aca041423cf3d423515fc4ecf8aa90a857556209773c628aR1-R18) [[2]](diffhunk://#diff-1d6d465a4f88ac492beb82dc08eb5fd9e87dfe564f43b39dd205b53f2aba9f2eR1-R13)
* Provided a `kustomization.yaml` to compose base resources, and a namespace manifest for scoping resources. [[1]](diffhunk://#diff-801aca405f1ec5cedd2fa6e9e48e1673bd563115f43c397f9da27c4ffa0edb41R1-R12) [[2]](diffhunk://#diff-af0ea21b44fb343e79dac03dac0177a760243ad7242c92df16f2631303ba2359R1-R6)

**Networking and Security**
* Added an `Ingress` manifest for the gateway service with NGINX annotations, and `NetworkPolicy` resources to enforce default deny and allow DNS egress, improving security posture. [[1]](diffhunk://#diff-ca4c65375f5cbfe314b45649c29474f669f60979487b4cec8606f415e5ceb024R1-R14) [[2]](diffhunk://#diff-2d0a94d4648579801210fa6083acd0b12c1acd290cf714d6297ab35ba89eb436R1-R13)

**GitOps and CI/CD Integration**
* Added an Argo CD `Application` manifest for pull-based, Git-driven deployment to the `vellumhub` namespace, starting in manual sync mode for controlled rollout.
* Updated the main `README.md` with sections on CI/CD and Kubernetes, documenting the build, publication, deployment, and rollback processes, emphasizing immutable image references and Git as the source of truth. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33-R34) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R296-R325)

**Documentation and Operational Guidance**
* Created a detailed `deploy/kubernetes/README.md` covering directory structure, local bootstrap with `kind`, production deployment, Argo CD setup, rollout/rollback procedures, and resource rationale for all services.

These changes establish a robust, secure, and auditable deployment pipeline for VellumHub, with clear separation of configuration, secrets, and infrastructure, and strong operational documentation for both local development and production environments.